### PR TITLE
feat: SEO 메타데이터 정합성과 인덱싱 정책 개선

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,15 +2,14 @@ import Image from "next/image";
 import Link from "next/link";
 import { CodeBracketIcon } from "@heroicons/react/24/outline";
 import type { Metadata } from "next";
-
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://changjun.dev";
+import { BASE_URL } from "@/shared/constants";
 
 export const metadata: Metadata = {
   title: "박창준 블로그 - 소개",
   description:
     "프론트엔드 개발자 박창준입니다. React와 Next.js를 활용한 웹 애플리케이션 개발에 집중하며, 기술 블로그를 통해 개발 경험과 학습한 내용을 공유합니다.",
   keywords: ["박창준", "프론트엔드", "개발자", "소개", "이력", "React", "Next.js", "TypeScript"],
-  authors: [{ name: "박창준", url: baseUrl }],
+  authors: [{ name: "박창준", url: BASE_URL }],
   creator: "박창준",
   publisher: "박창준",
   alternates: {
@@ -23,10 +22,10 @@ export const metadata: Metadata = {
     type: "profile",
     locale: "ko_KR",
     siteName: "박창준",
-    url: `${baseUrl}/about`,
+    url: `${BASE_URL}/about`,
     images: [
       {
-        url: `${baseUrl}/logo.png`,
+        url: `${BASE_URL}/logo.png`,
         width: 1200,
         height: 630,
         alt: "박창준 블로그 - 소개",
@@ -34,11 +33,8 @@ export const metadata: Metadata = {
     ],
   },
   twitter: {
-    card: "summary_large_image",
     title: "박창준 블로그 - 소개",
     description: "프론트엔드 개발자 박창준입니다.",
-    creator: "@changjun",
-    images: [`${baseUrl}/logo.png`],
   },
 };
 
@@ -47,7 +43,7 @@ const aboutPersonSchema = {
   "@context": "https://schema.org",
   "@type": "Person",
   name: "박창준",
-  url: baseUrl,
+  url: BASE_URL,
   jobTitle: "프론트엔드 개발자",
   description:
     "프론트엔드 개발자 박창준입니다. React와 Next.js를 활용한 웹 애플리케이션 개발에 집중하며, 기술 블로그를 통해 개발 경험과 학습한 내용을 공유합니다.",

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -13,6 +13,9 @@ export const metadata: Metadata = {
   authors: [{ name: "박창준", url: baseUrl }],
   creator: "박창준",
   publisher: "박창준",
+  alternates: {
+    canonical: "/about",
+  },
   openGraph: {
     title: "박창준 블로그 - 소개",
     description:
@@ -21,12 +24,21 @@ export const metadata: Metadata = {
     locale: "ko_KR",
     siteName: "박창준",
     url: `${baseUrl}/about`,
+    images: [
+      {
+        url: `${baseUrl}/logo.png`,
+        width: 1200,
+        height: 630,
+        alt: "박창준 블로그 - 소개",
+      },
+    ],
   },
   twitter: {
-    card: "summary",
+    card: "summary_large_image",
     title: "박창준 블로그 - 소개",
     description: "프론트엔드 개발자 박창준입니다.",
     creator: "@changjun",
+    images: [`${baseUrl}/logo.png`],
   },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "@/shared/providers/ThemeProvider";
 import { Footer } from "@/shared/ui/Footer";
+import { BASE_URL } from "@/shared/constants";
 import { ClientLayout } from "./ClientLayout";
 import type { Metadata } from "next";
 
@@ -17,8 +18,6 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
-
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://changjun.dev";
 
 export const metadata: Metadata = {
   title: {
@@ -38,15 +37,15 @@ export const metadata: Metadata = {
     "웹 개발",
     "기술 블로그",
   ],
-  authors: [{ name: "박창준", url: baseUrl }],
+  authors: [{ name: "박창준", url: BASE_URL }],
   creator: "박창준",
   publisher: "박창준",
-  metadataBase: new URL(baseUrl),
+  metadataBase: new URL(BASE_URL),
   alternates: {
     types: {
-      "application/rss+xml": `${baseUrl}/feed.xml`,
-      "application/feed+json": `${baseUrl}/feed.json`,
-      "application/atom+xml": `${baseUrl}/atom.xml`,
+      "application/rss+xml": `${BASE_URL}/feed.xml`,
+      "application/feed+json": `${BASE_URL}/feed.json`,
+      "application/atom+xml": `${BASE_URL}/atom.xml`,
     },
   },
   robots: {
@@ -67,10 +66,10 @@ export const metadata: Metadata = {
     title: "박창준 블로그",
     description:
       "박창준의 기술 블로그입니다. 프론트엔드 개발자 박창준이 React, Next.js, TypeScript 등 웹 개발 경험과 지식을 공유합니다.",
-    url: baseUrl,
+    url: BASE_URL,
     images: [
       {
-        url: `${baseUrl}/logo.png`,
+        url: `${BASE_URL}/logo.png`,
         width: 1200,
         height: 630,
         alt: "박창준 블로그",
@@ -83,7 +82,7 @@ export const metadata: Metadata = {
     description:
       "박창준의 기술 블로그입니다. 프론트엔드 개발자 박창준이 React, Next.js, TypeScript 등 웹 개발 경험과 지식을 공유합니다.",
     creator: "@changjun",
-    images: [`${baseUrl}/logo.png`],
+    images: [`${BASE_URL}/logo.png`],
   },
   verification: {
     google: "KkCn5ZoWWUotKW-IU9GakGgXxxoLeAzeeBSig3BvUIQ",
@@ -103,7 +102,7 @@ const personSchema = {
   "@context": "https://schema.org",
   "@type": "Person",
   name: "박창준",
-  url: baseUrl,
+  url: BASE_URL,
   jobTitle: "프론트엔드 개발자",
   description:
     "프론트엔드 개발자 박창준의 기술 블로그입니다. React, Next.js, TypeScript 등 웹 개발 경험과 지식을 공유합니다.",
@@ -115,11 +114,14 @@ const websiteSchema = {
   "@context": "https://schema.org",
   "@type": "WebSite",
   name: "박창준 블로그",
-  url: baseUrl,
+  url: BASE_URL,
   inLanguage: "ko-KR",
   potentialAction: {
     "@type": "SearchAction",
-    target: `${baseUrl}/search?q={search_term_string}`,
+    target: {
+      "@type": "EntryPoint",
+      urlTemplate: `${BASE_URL}/search?q={search_term_string}`,
+    },
     "query-input": "required name=search_term_string",
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,6 +49,17 @@ export const metadata: Metadata = {
       "application/atom+xml": `${baseUrl}/atom.xml`,
     },
   },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
   openGraph: {
     type: "website",
     locale: "ko_KR",
@@ -57,6 +68,22 @@ export const metadata: Metadata = {
     description:
       "박창준의 기술 블로그입니다. 프론트엔드 개발자 박창준이 React, Next.js, TypeScript 등 웹 개발 경험과 지식을 공유합니다.",
     url: baseUrl,
+    images: [
+      {
+        url: `${baseUrl}/logo.png`,
+        width: 1200,
+        height: 630,
+        alt: "박창준 블로그",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "박창준 블로그",
+    description:
+      "박창준의 기술 블로그입니다. 프론트엔드 개발자 박창준이 React, Next.js, TypeScript 등 웹 개발 경험과 지식을 공유합니다.",
+    creator: "@changjun",
+    images: [`${baseUrl}/logo.png`],
   },
   verification: {
     google: "KkCn5ZoWWUotKW-IU9GakGgXxxoLeAzeeBSig3BvUIQ",
@@ -84,6 +111,19 @@ const personSchema = {
   knowsAbout: ["프론트엔드 개발", "React", "Next.js", "TypeScript", "JavaScript", "웹 개발"],
 };
 
+const websiteSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "박창준 블로그",
+  url: baseUrl,
+  inLanguage: "ko-KR",
+  potentialAction: {
+    "@type": "SearchAction",
+    target: `${baseUrl}/search?q={search_term_string}`,
+    "query-input": "required name=search_term_string",
+  },
+};
+
 export default async function RootLayout({
   children,
 }: Readonly<{
@@ -101,6 +141,7 @@ export default async function RootLayout({
           본문으로 바로가기
         </a>
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }} />
         <Providers>
           <ClientLayout>
             {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import { PostList } from "../entities/post/ui/PostList";
 
 // Post API 어댑터 초기화
 import "@/app/init-post-api";
-import { POSTS_PER_PAGE } from "@/shared/constants";
+import { BASE_URL, POSTS_PER_PAGE } from "@/shared/constants";
 
 // 프로덕션 빌드 시에는 force-static으로 변경 필요
 export const dynamic = "force-static";
@@ -24,8 +24,6 @@ export default async function Home() {
 }
 
 export async function generateMetadata() {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://changjun.dev";
-
   return {
     title: "박창준 블로그",
     description:
@@ -41,7 +39,7 @@ export async function generateMetadata() {
       "웹 개발",
       "기술 블로그",
     ],
-    authors: [{ name: "박창준", url: baseUrl }],
+    authors: [{ name: "박창준", url: BASE_URL }],
     creator: "박창준",
     publisher: "박창준",
     alternates: {
@@ -54,23 +52,15 @@ export async function generateMetadata() {
       type: "website",
       locale: "ko_KR",
       siteName: "박창준",
-      url: baseUrl,
+      url: BASE_URL,
       images: [
         {
-          url: `${baseUrl}/logo.png`,
+          url: `${BASE_URL}/logo.png`,
           width: 1200,
           height: 630,
           alt: "박창준 블로그",
         },
       ],
-    },
-    twitter: {
-      card: "summary_large_image",
-      title: "박창준 블로그",
-      description:
-        "박창준의 기술 블로그입니다. 프론트엔드 개발자 박창준이 React, Next.js, TypeScript 등 웹 개발 경험과 지식을 공유합니다.",
-      creator: "@changjun",
-      images: [`${baseUrl}/logo.png`],
     },
   };
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,6 +44,9 @@ export async function generateMetadata() {
     authors: [{ name: "박창준", url: baseUrl }],
     creator: "박창준",
     publisher: "박창준",
+    alternates: {
+      canonical: "/",
+    },
     openGraph: {
       title: "박창준 블로그",
       description:
@@ -52,6 +55,14 @@ export async function generateMetadata() {
       locale: "ko_KR",
       siteName: "박창준",
       url: baseUrl,
+      images: [
+        {
+          url: `${baseUrl}/logo.png`,
+          width: 1200,
+          height: 630,
+          alt: "박창준 블로그",
+        },
+      ],
     },
     twitter: {
       card: "summary_large_image",
@@ -59,6 +70,7 @@ export async function generateMetadata() {
       description:
         "박창준의 기술 블로그입니다. 프론트엔드 개발자 박창준이 React, Next.js, TypeScript 등 웹 개발 경험과 지식을 공유합니다.",
       creator: "@changjun",
+      images: [`${baseUrl}/logo.png`],
     },
   };
 }

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -50,7 +50,7 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
 
   try {
     const post = await getPostBySlugCached(slug);
-    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://blog.changjun.dev";
+    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://changjun.dev";
     const postUrl = `${baseUrl}/posts/${slug}`;
 
     // 설명 생성 (excerpt가 없으면 제목 기반)
@@ -177,7 +177,7 @@ export default async function PostPage({ params }: PostPageProps) {
       currentIndex < allPosts.length - 1 ? await getPostBySlugCached(allPosts[currentIndex + 1].slug, false) : undefined;
 
     // JSON-LD 구조화된 데이터
-    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://blog.changjun.dev";
+    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://changjun.dev";
 
     // OG Image와 동일한 로직으로 이미지 선택
     let jsonLdImage: string | undefined = undefined;

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -22,6 +22,7 @@ import { PostViewCounter } from "@/features/page-views";
 import { PostNavigation } from "@/widgets/post-navigation";
 import { ScrollProgress } from "@/shared/ui/ScrollProgress";
 import BottomNavigation from "@/shared/ui/BottomNavigation";
+import { BASE_URL } from "@/shared/constants";
 import type { Metadata } from "next";
 
 interface PostPageProps {
@@ -50,8 +51,7 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
 
   try {
     const post = await getPostBySlugCached(slug);
-    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://changjun.dev";
-    const postUrl = `${baseUrl}/posts/${slug}`;
+    const postUrl = `${BASE_URL}/posts/${slug}`;
 
     // 설명 생성 (excerpt가 없으면 제목 기반)
     const description = post.excerpt || `${post.title}에 대한 상세한 내용을 다룹니다. `;
@@ -66,17 +66,17 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
     if (post.coverImage) {
       ogImageUrl = post.coverImage.startsWith("http")
         ? post.coverImage
-        : `${baseUrl}${post.coverImage.startsWith("/") ? post.coverImage : `/${post.coverImage}`}`;
+        : `${BASE_URL}${post.coverImage.startsWith("/") ? post.coverImage : `/${post.coverImage}`}`;
     } else {
       // 2. 포스트 콘텐츠에서 첫 번째 이미지 찾기
       const firstImageUrl = getFirstImageFromContent(post.content);
       if (firstImageUrl) {
         ogImageUrl = firstImageUrl.startsWith("http")
           ? firstImageUrl
-          : `${baseUrl}${firstImageUrl.startsWith("/") ? firstImageUrl : `/${firstImageUrl}`}`;
+          : `${BASE_URL}${firstImageUrl.startsWith("/") ? firstImageUrl : `/${firstImageUrl}`}`;
       } else {
         // 3. 이미지가 없으면 동적 생성된 OG 이미지 사용
-        ogImageUrl = `${baseUrl}/posts/${slug}/opengraph-image`;
+        ogImageUrl = `${BASE_URL}/posts/${slug}/opengraph-image`;
       }
     }
 
@@ -84,7 +84,7 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
       title: `${post.title}`,
       description: description.slice(0, 160), // 검색엔진 최적 길이
       keywords: keywords.join(", "),
-      authors: [{ name: "박창준", url: baseUrl }],
+      authors: [{ name: "박창준", url: BASE_URL }],
       creator: "박창준",
       publisher: "박창준",
 
@@ -177,20 +177,18 @@ export default async function PostPage({ params }: PostPageProps) {
       currentIndex < allPosts.length - 1 ? await getPostBySlugCached(allPosts[currentIndex + 1].slug, false) : undefined;
 
     // JSON-LD 구조화된 데이터
-    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://changjun.dev";
-
     // OG Image와 동일한 로직으로 이미지 선택
     let jsonLdImage: string | undefined = undefined;
     if (post.coverImage) {
       jsonLdImage = post.coverImage.startsWith("http")
         ? post.coverImage
-        : `${baseUrl}${post.coverImage.startsWith("/") ? post.coverImage : `/${post.coverImage}`}`;
+        : `${BASE_URL}${post.coverImage.startsWith("/") ? post.coverImage : `/${post.coverImage}`}`;
     } else {
       const firstImageUrl = getFirstImageFromContent(post.content);
       if (firstImageUrl) {
         jsonLdImage = firstImageUrl.startsWith("http")
           ? firstImageUrl
-          : `${baseUrl}${firstImageUrl.startsWith("/") ? firstImageUrl : `/${firstImageUrl}`}`;
+          : `${BASE_URL}${firstImageUrl.startsWith("/") ? firstImageUrl : `/${firstImageUrl}`}`;
       }
     }
 
@@ -205,16 +203,16 @@ export default async function PostPage({ params }: PostPageProps) {
       author: {
         "@type": "Person",
         name: "박창준",
-        url: baseUrl,
+        url: BASE_URL,
       },
       publisher: {
         "@type": "Person",
         name: "박창준",
-        url: baseUrl,
+        url: BASE_URL,
       },
       mainEntityOfPage: {
         "@type": "WebPage",
-        "@id": `${baseUrl}/posts/${slug}`,
+        "@id": `${BASE_URL}/posts/${slug}`,
       },
       keywords: [...post.tags.map((tag) => tag.name)].join(", "),
       articleSection: post.tags.map((tag) => tag.name).join(", "),

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -57,9 +57,24 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
 export async function generateMetadata({ searchParams }: SearchPageProps) {
   const params = await searchParams;
   const query = params.q?.trim();
+  const hasQuery = Boolean(query);
 
   return {
     title: query ? `검색: ${query}` : "검색",
     description: query ? `${query} 검색 결과` : "블로그 포스트를 검색해보세요",
+    alternates: {
+      canonical: "/search",
+    },
+    robots: {
+      index: false,
+      follow: true,
+      googleBot: {
+        index: false,
+        follow: true,
+        "max-video-preview": -1,
+        "max-image-preview": "large",
+        "max-snippet": hasQuery ? 0 : -1,
+      },
+    },
   };
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -57,7 +57,6 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
 export async function generateMetadata({ searchParams }: SearchPageProps) {
   const params = await searchParams;
   const query = params.q?.trim();
-  const hasQuery = Boolean(query);
 
   return {
     title: query ? `검색: ${query}` : "검색",
@@ -73,7 +72,7 @@ export async function generateMetadata({ searchParams }: SearchPageProps) {
         follow: true,
         "max-video-preview": -1,
         "max-image-preview": "large",
-        "max-snippet": hasQuery ? 0 : -1,
+        "max-snippet": -1,
       },
     },
   };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,16 +1,15 @@
 import { MetadataRoute } from "next";
 import { getAllPosts } from "@/entities/post/api";
+import { BASE_URL } from "@/shared/constants";
 import "@/app/init-post-api";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://changjun.dev";
-
   // 모든 포스트 가져오기
   const posts = await getAllPosts();
 
   // 포스트 URL 생성
   const postUrls = posts.map((post) => ({
-    url: `${baseUrl}/posts/${post.slug}`,
+    url: `${BASE_URL}/posts/${post.slug}`,
     lastModified: new Date(post.updatedAt),
     changeFrequency: "weekly" as const,
     priority: 0.8,
@@ -19,13 +18,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // 정적 페이지들
   const routes = [
     {
-      url: baseUrl,
+      url: BASE_URL,
       lastModified: new Date(),
       changeFrequency: "daily" as const,
       priority: 1,
     },
     {
-      url: `${baseUrl}/about`,
+      url: `${BASE_URL}/about`,
       lastModified: new Date(),
       changeFrequency: "monthly" as const,
       priority: 0.5,

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,3 +1,4 @@
 const POSTS_PER_PAGE = 20 as const;
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://changjun.dev";
 
-export { POSTS_PER_PAGE };
+export { BASE_URL, POSTS_PER_PAGE };


### PR DESCRIPTION
## Summary
- 전역 메타데이터에 robots/Twitter/OG 기본값과 `WebSite + SearchAction` JSON-LD를 추가해 검색엔진 해석 신호를 강화했습니다.
- 홈(`/`), 소개(`/about`), 검색(`/search`)에 canonical을 명시하고, 검색 페이지를 noindex로 설정해 쿼리 기반 중복 인덱싱을 줄였습니다.
- 포스트 페이지의 base URL 기본값을 사이트 전체와 동일하게 맞춰 canonical/OG/JSON-LD URL 정합성을 개선했습니다.

## Verification
- `pnpm lint`
- `pnpm typecheck`