### PR TITLE
refactor: shared/ui 의존성 역전 수정 및 barrel export 추가

### DIFF
--- a/src/app/ClientLayout.tsx
+++ b/src/app/ClientLayout.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { useMemo } from "react";
-import { HeaderPlugin } from "@/shared/ui/Header/types";
-import { Header } from "@/shared/ui/Header";
 import {
+  Header,
   createLogoPlugin,
   createNavigationPlugin,
   createSearchPlugin,
   createMobileSearchPlugin,
   createThemeTogglePlugin,
-} from "@/shared/ui/Header/index";
+} from "@/shared/ui";
+import type { HeaderPlugin } from "@/shared/ui";
 
 interface ClientLayoutProps {
   children: React.ReactNode;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "@/shared/providers/ThemeProvider";
-import { Footer } from "@/shared/ui/Footer";
+import { Footer } from "@/shared/ui";
 import { BASE_URL } from "@/shared/constants";
 import { ClientLayout } from "./ClientLayout";
 import type { Metadata } from "next";

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -20,8 +20,7 @@ import { PostViewCounter } from "@/features/page-views";
 
 // widgets
 import { PostNavigation } from "@/widgets/post-navigation";
-import { ScrollProgress } from "@/shared/ui/ScrollProgress";
-import BottomNavigation from "@/shared/ui/BottomNavigation";
+import { ScrollProgress, BottomNavigation } from "@/shared/ui";
 import { BASE_URL } from "@/shared/constants";
 import type { Metadata } from "next";
 

--- a/src/entities/post/ui/ClientPagination.tsx
+++ b/src/entities/post/ui/ClientPagination.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pagination } from "@/shared/ui/Pagination";
+import { Pagination } from "@/shared/ui";
 
 interface ClientPaginationProps {
   currentPage: number;

--- a/src/entities/post/ui/PostContent.tsx
+++ b/src/entities/post/ui/PostContent.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment } from "react";
 import type { ContentBlockWithChildren } from "@/shared/types/content";
-import { ContentBlockRenderer } from "@/shared/ui/ContentBlockRenderer";
+import { ContentBlockRenderer } from "@/features/notion/ui/ContentBlockRenderer";
 import { SELF_CONTAINED_BLOCK_TYPES } from "@/shared/utils/blockGrouping";
 
 interface PostContentProps {

--- a/src/features/notion/ui/ContentBlockRenderer.tsx
+++ b/src/features/notion/ui/ContentBlockRenderer.tsx
@@ -14,8 +14,8 @@ interface ContentBlockRendererProps {
 }
 
 /**
- * 공통 콘텐츠 블록을 렌더링하는 컴포넌트
- * CMS에 독립적으로 작동하며, 다양한 소스의 블록을 렌더링할 수 있습니다.
+ * 콘텐츠 블록을 렌더링하는 컴포넌트
+ * Notion 블록 데이터를 받아 적절한 UI로 변환합니다.
  */
 export function ContentBlockRenderer({
   block,

--- a/src/features/notion/ui/blocks/ImageWithModal.tsx
+++ b/src/features/notion/ui/blocks/ImageWithModal.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import { ImageBlock } from "./ImageBlock";
-import { Modal } from "@/shared/ui/Modal";
+import { Modal } from "@/shared/ui";
 import { getOptimizedImageUrl } from "@/shared/utils/imageMapper";
 
 interface ImageWithModalProps {

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -10,3 +10,10 @@ export { Footer } from "./Footer";
 export { Pagination } from "./Pagination";
 export { default as BottomNavigation } from "./BottomNavigation";
 export type { HeaderPlugin, HeaderSectionProps } from "./Header/types";
+export {
+  createLogoPlugin,
+  createNavigationPlugin,
+  createSearchPlugin,
+  createMobileSearchPlugin,
+  createThemeTogglePlugin,
+} from "./Header";

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,0 +1,12 @@
+// Primitives
+export { Modal } from "./Modal";
+
+// Feedback
+export { ScrollProgress } from "./ScrollProgress";
+
+// Navigation
+export { Header } from "./Header";
+export { Footer } from "./Footer";
+export { Pagination } from "./Pagination";
+export { default as BottomNavigation } from "./BottomNavigation";
+export type { HeaderPlugin, HeaderSectionProps } from "./Header/types";


### PR DESCRIPTION
## Summary
- `ContentBlockRenderer`가 `shared/ui/`에서 `features/notion/`을 import하여 레이어드 아키텍처를 위반하고 있었음
- Notion 전용 컴포넌트이므로 `features/notion/ui/`로 이동하여 의존성 방향 수정
- `shared/ui/index.ts` barrel export 추가로 깔끔한 import 경로 제공

## Changes
| File | Change |
|------|--------|
| `src/features/notion/ui/ContentBlockRenderer.tsx` | `shared/ui/`에서 이동 |
| `src/shared/ui/ContentBlockRenderer.tsx` | 삭제 |
| `src/entities/post/ui/PostContent.tsx` | import 경로 업데이트 |
| `src/shared/ui/index.ts` | 신규 barrel export |

## Test plan
- [x] `pnpm lint` 통과
- [x] `pnpm build` 통과 (21개 라우트 정상 빌드)
- [x] `grep -r "ContentBlockRenderer" src/shared/` → 0건 (완전 이동 확인)
- [ ] 포스트 페이지에서 콘텐츠 블록(코드, 이미지, 테이블 등) 정상 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)