### PR TITLE
fix: 이미지 원본 크기대로 표시되도록 반응형 축소 제거

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,24 +41,6 @@ body {
   height: auto;
 }
 
-@media (min-width: 768px) {
-  .prose img {
-    max-width: 90%;
-  }
-}
-
-@media (min-width: 1024px) {
-  .prose img {
-    max-width: 80%;
-  }
-}
-
-@media (min-width: 1280px) {
-  .prose img {
-    max-width: 70%;
-  }
-}
-
 /* Search result highlight styles */
 mark {
   background-color: #fef3c7;


### PR DESCRIPTION
## Summary
- 데스크톱에서 이미지가 70%까지 축소되는 미디어 쿼리 제거
- `max-width: 100%`만 유지하여 이미지가 원본 크기대로 표시

## Changes
`src/app/globals.css`에서 768px/1024px/1280px 미디어 쿼리 3개 제거

## Test plan
- [ ] 포스트 페이지에서 이미지가 컨테이너 전체 너비로 표시되는지 확인
- [ ] 모바일에서 이미지가 넘치지 않는지 확인 (max-width: 100% 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)