### PR TITLE
feat: JSON-LD 구조화 데이터 강화

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,12 +9,40 @@ import { BASE_URL, POSTS_PER_PAGE } from "@/shared/constants";
 export const dynamic = "force-static";
 export const revalidate = 3600; // 1시간마다 재검증
 
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "박창준 블로그",
+  url: BASE_URL,
+  description: "개발자 박창준 블로그입니다.",
+  inLanguage: "ko-KR",
+  author: {
+    "@type": "Person",
+    name: "박창준",
+    url: BASE_URL,
+  },
+  publisher: {
+    "@type": "Person",
+    name: "박창준",
+    url: BASE_URL,
+  },
+  potentialAction: {
+    "@type": "SearchAction",
+    target: {
+      "@type": "EntryPoint",
+      urlTemplate: `${BASE_URL}/search?q={search_term_string}`,
+    },
+    "query-input": "required name=search_term_string",
+  },
+};
+
 export default async function Home() {
   const allPosts = await getAllPosts();
   const sortedPosts = allPosts.sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
 
   return (
     <div className="text-gray-900 dark:text-white">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }} />
       <div className="py-8">
         {/* 클라이언트 컴포넌트로 전체 포스트 전달 */}
         <PostList posts={sortedPosts} postsPerPage={POSTS_PER_PAGE} />

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -7,6 +7,29 @@ import { getAllPosts, getPostBySlug } from "@/entities/post/api";
 // Notion feature (유틸리티만 사용)
 import { generateTableOfContents } from "@/features/notion";
 import { getFirstImageFromContent } from "@/features/notion/utils/blockParser";
+import type { ContentBlockWithChildren, RichTextItem } from "@/shared/types/content";
+
+// 블록에서 실제 단어 수를 계산 (한/영 혼용: 공백 기준 + CJK 문자 개별 카운트)
+function countWordsInBlocks(blocks: ContentBlockWithChildren[]): number {
+  const extractText = (items?: RichTextItem[]): string =>
+    items?.map((item) => item.plain_text).join(" ") ?? "";
+
+  let total = 0;
+  const walk = (nodes: ContentBlockWithChildren[]) => {
+    for (const node of nodes) {
+      const text = extractText(node.richText) || node.fallbackText || node.code || "";
+      if (text) {
+        const nonCjk = text.replace(/[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff\uac00-\ud7af]/g, " ");
+        const words = nonCjk.trim().split(/\s+/).filter(Boolean).length;
+        const cjk = (text.match(/[\u4e00-\u9fff\uac00-\ud7af]/g) ?? []).length;
+        total += words + cjk;
+      }
+      if (node.children?.length) walk(node.children);
+    }
+  };
+  walk(blocks);
+  return total;
+}
 
 // Post API 어댑터 초기화
 import "@/app/init-post-api";
@@ -215,12 +238,32 @@ export default async function PostPage({ params }: PostPageProps) {
       },
       keywords: [...post.tags.map((tag) => tag.name)].join(", "),
       articleSection: post.tags.map((tag) => tag.name).join(", "),
-      wordCount: post.content.length * 100, // 대략적인 단어 수
+      wordCount: countWordsInBlocks(post.content),
+    };
+
+    const breadcrumbJsonLd = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "홈",
+          item: BASE_URL,
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: post.title,
+          item: `${BASE_URL}/posts/${slug}`,
+        },
+      ],
     };
 
     return (
       <>
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
         <ScrollProgress />
         <div className="py-10">
           <div className="mx-auto w-full">


### PR DESCRIPTION
## Summary
- 홈 페이지에 `WebSite` + `SearchAction` JSON-LD 스키마 추가 → 구글 사이트링크 검색박스 노출 가능
- 포스트 페이지에 `BreadcrumbList` 스키마 추가 → 검색 결과에 경로 표시
- `wordCount`를 블록 기반 실제 단어 수 계산으로 교체 (기존: `content.length * 100` 부정확) — 한글(CJK)/영문 혼용 지원

## Test plan
- [x] `tsc --noEmit` 통과
- [ ] 빌드 후 `view-source`에서 `<script type="application/ld+json">` 출력 확인
- [ ] [Google Rich Results Test](https://search.google.com/test/rich-results)로 BlogPosting / BreadcrumbList / WebSite 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)