### PR TITLE
feat: Notion 빌드 결과 디스크 캐싱

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ next-env.d.ts
 /public/images/*/
 /public/images/image-mapping.json
 /src/shared/utils/imageMapping.generated.ts
+
+# notion build cache
+/.cache/

--- a/src/features/notion/service/notion-cache.ts
+++ b/src/features/notion/service/notion-cache.ts
@@ -1,5 +1,3 @@
-import fs from "fs";
-import path from "path";
 import type { NotionBlock } from "../types";
 
 /**
@@ -13,29 +11,49 @@ import type { NotionBlock } from "../types";
  * 캐시 구조:
  *   .cache/notion/
  *   └── pages/{pageId}.json   { lastEditedTime, blocks }
+ *
+ * 주의: Edge Runtime(opengraph-image 등)에서는 fs/path를 사용할 수 없으므로
+ * Node 런타임에서만 동작하고, Edge에서는 자동으로 no-op가 됩니다.
  */
-
-const CACHE_ROOT = path.join(process.cwd(), ".cache", "notion");
-const PAGES_DIR = path.join(CACHE_ROOT, "pages");
-
-// 캐시 비활성화 환경 변수 (CI에서 강제 풀 빌드용)
-const CACHE_DISABLED = process.env.NOTION_CACHE_DISABLED === "true";
 
 interface PageBlocksCacheEntry {
   lastEditedTime: string;
   blocks: NotionBlock[];
 }
 
-function ensureDir(dir: string) {
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
+// Node 런타임에서만 fs/path 모듈 로드 (eval로 webpack 정적 분석 회피)
+function getNodeModules(): { fs: typeof import("fs"); path: typeof import("path") } | null {
+  if (typeof process === "undefined" || !process.versions?.node) return null;
+  // @ts-expect-error - EdgeRuntime은 Edge 환경에서만 정의됨
+  if (typeof EdgeRuntime !== "undefined") return null;
+  try {
+    // eval을 사용해 webpack이 fs/path를 번들에 포함하지 않도록 함
+    const req = eval("require") as NodeRequire;
+    return { fs: req("fs"), path: req("path") };
+  } catch {
+    return null;
   }
 }
 
-function getPageCachePath(pageId: string): string {
-  // pageId의 하이픈을 제거하여 파일명으로 사용
+const CACHE_DISABLED = typeof process !== "undefined" && process.env.NOTION_CACHE_DISABLED === "true";
+
+function getCachePaths() {
+  const mods = getNodeModules();
+  if (!mods) return null;
+  const root = mods.path.join(process.cwd(), ".cache", "notion");
+  return {
+    fs: mods.fs,
+    path: mods.path,
+    root,
+    pagesDir: mods.path.join(root, "pages"),
+  };
+}
+
+function getPageCachePath(pageId: string): string | null {
+  const ctx = getCachePaths();
+  if (!ctx) return null;
   const safeId = pageId.replace(/-/g, "");
-  return path.join(PAGES_DIR, `${safeId}.json`);
+  return ctx.path.join(ctx.pagesDir, `${safeId}.json`);
 }
 
 /**
@@ -44,19 +62,20 @@ function getPageCachePath(pageId: string): string {
  */
 export function readPageBlocksCache(pageId: string, lastEditedTime: string): NotionBlock[] | null {
   if (CACHE_DISABLED) return null;
+  const ctx = getCachePaths();
+  if (!ctx) return null;
 
   const cachePath = getPageCachePath(pageId);
-  if (!fs.existsSync(cachePath)) return null;
+  if (!cachePath || !ctx.fs.existsSync(cachePath)) return null;
 
   try {
-    const raw = fs.readFileSync(cachePath, "utf-8");
+    const raw = ctx.fs.readFileSync(cachePath, "utf-8");
     const entry = JSON.parse(raw) as PageBlocksCacheEntry;
     if (entry.lastEditedTime === lastEditedTime) {
       return entry.blocks;
     }
     return null;
   } catch {
-    // 파싱 실패 시 캐시 무효화
     return null;
   }
 }
@@ -66,18 +85,26 @@ export function readPageBlocksCache(pageId: string, lastEditedTime: string): Not
  */
 export function writePageBlocksCache(pageId: string, lastEditedTime: string, blocks: NotionBlock[]): void {
   if (CACHE_DISABLED) return;
+  const ctx = getCachePaths();
+  if (!ctx) return;
 
-  ensureDir(PAGES_DIR);
+  if (!ctx.fs.existsSync(ctx.pagesDir)) {
+    ctx.fs.mkdirSync(ctx.pagesDir, { recursive: true });
+  }
   const cachePath = getPageCachePath(pageId);
+  if (!cachePath) return;
+
   const entry: PageBlocksCacheEntry = { lastEditedTime, blocks };
-  fs.writeFileSync(cachePath, JSON.stringify(entry));
+  ctx.fs.writeFileSync(cachePath, JSON.stringify(entry));
 }
 
 /**
  * 캐시 디렉터리 전체 삭제 (테스트/디버깅용).
  */
 export function clearNotionCache(): void {
-  if (fs.existsSync(CACHE_ROOT)) {
-    fs.rmSync(CACHE_ROOT, { recursive: true, force: true });
+  const ctx = getCachePaths();
+  if (!ctx) return;
+  if (ctx.fs.existsSync(ctx.root)) {
+    ctx.fs.rmSync(ctx.root, { recursive: true, force: true });
   }
 }

--- a/src/features/notion/service/notion-cache.ts
+++ b/src/features/notion/service/notion-cache.ts
@@ -1,0 +1,83 @@
+import fs from "fs";
+import path from "path";
+import type { NotionBlock } from "../types";
+
+/**
+ * Notion API 응답을 디스크에 캐싱하는 레이어.
+ *
+ * 핵심 아이디어:
+ * - 페이지의 `last_edited_time`을 캐시 키로 사용
+ * - 캐시된 값과 일치하면 API를 호출하지 않고 디스크에서 읽음
+ * - 로컬/CI 빌드 시간을 극적으로 단축
+ *
+ * 캐시 구조:
+ *   .cache/notion/
+ *   └── pages/{pageId}.json   { lastEditedTime, blocks }
+ */
+
+const CACHE_ROOT = path.join(process.cwd(), ".cache", "notion");
+const PAGES_DIR = path.join(CACHE_ROOT, "pages");
+
+// 캐시 비활성화 환경 변수 (CI에서 강제 풀 빌드용)
+const CACHE_DISABLED = process.env.NOTION_CACHE_DISABLED === "true";
+
+interface PageBlocksCacheEntry {
+  lastEditedTime: string;
+  blocks: NotionBlock[];
+}
+
+function ensureDir(dir: string) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function getPageCachePath(pageId: string): string {
+  // pageId의 하이픈을 제거하여 파일명으로 사용
+  const safeId = pageId.replace(/-/g, "");
+  return path.join(PAGES_DIR, `${safeId}.json`);
+}
+
+/**
+ * 캐시된 블록을 읽어옴.
+ * lastEditedTime이 일치할 때만 반환, 그렇지 않으면 null.
+ */
+export function readPageBlocksCache(pageId: string, lastEditedTime: string): NotionBlock[] | null {
+  if (CACHE_DISABLED) return null;
+
+  const cachePath = getPageCachePath(pageId);
+  if (!fs.existsSync(cachePath)) return null;
+
+  try {
+    const raw = fs.readFileSync(cachePath, "utf-8");
+    const entry = JSON.parse(raw) as PageBlocksCacheEntry;
+    if (entry.lastEditedTime === lastEditedTime) {
+      return entry.blocks;
+    }
+    return null;
+  } catch {
+    // 파싱 실패 시 캐시 무효화
+    return null;
+  }
+}
+
+/**
+ * 블록을 디스크 캐시에 저장.
+ */
+export function writePageBlocksCache(pageId: string, lastEditedTime: string, blocks: NotionBlock[]): void {
+  if (CACHE_DISABLED) return;
+
+  ensureDir(PAGES_DIR);
+  const cachePath = getPageCachePath(pageId);
+  const entry: PageBlocksCacheEntry = { lastEditedTime, blocks };
+  fs.writeFileSync(cachePath, JSON.stringify(entry));
+}
+
+/**
+ * 캐시 디렉터리 전체 삭제 (테스트/디버깅용).
+ */
+export function clearNotionCache(): void {
+  if (fs.existsSync(CACHE_ROOT)) {
+    fs.rmSync(CACHE_ROOT, { recursive: true, force: true });
+  }
+}

--- a/src/features/notion/service/notion-client.ts
+++ b/src/features/notion/service/notion-client.ts
@@ -16,6 +16,7 @@ import type {
 } from "../types";
 import type { BlogPost } from "@/entities/post/model";
 import { adaptNotionBlocksToContentBlocks } from "../utils/blockAdapter";
+import { readPageBlocksCache, writePageBlocksCache } from "./notion-cache";
 
 // Singleton client instance
 let client: Client | null = null;
@@ -144,17 +145,27 @@ export async function getPostBySlug(slug: string, fetchContent = true): Promise<
 
 // pageId로 직접 포스트 조회
 export async function getPostByPageId(pageId: string, fetchContent = true): Promise<BlogPost> {
-  // ✅ API 병렬 호출로 성능 최적화
-  const pageDataPromise = getClient().pages.retrieve({ page_id: pageId });
-  const blocksPromise = fetchContent ? getPostBlocks(pageId) : Promise.resolve([]);
-
-  const [pageData, blocks] = await Promise.all([pageDataPromise, blocksPromise]);
+  // 페이지 메타데이터를 먼저 가져와서 last_edited_time으로 캐시 유효성 판단
+  const pageData = await getClient().pages.retrieve({ page_id: pageId });
 
   if (!("properties" in pageData)) {
     throw new Error("Invalid page");
   }
 
   const page = pageData as NotionPage;
+
+  // 블록 조회: 캐시 우선, 미스 시 API 호출
+  let blocks: NotionBlock[] = [];
+  if (fetchContent) {
+    const cached = readPageBlocksCache(page.id, page.last_edited_time);
+    if (cached) {
+      blocks = cached;
+    } else {
+      blocks = await getPostBlocks(page.id);
+      writePageBlocksCache(page.id, page.last_edited_time, blocks);
+    }
+  }
+
   const properties = page.properties;
 
   const title = getPlainText(properties.title) || "Untitled";


### PR DESCRIPTION
## Summary
- `last_edited_time` 기반 디스크 캐시 레이어 추가 (`.cache/notion/pages/{pageId}.json`)
- `getPostByPageId`가 페이지 메타데이터를 먼저 조회 → 캐시 히트 시 무거운 `getPostBlocks` 재귀 호출 스킵
- 환경변수 `NOTION_CACHE_DISABLED=true`로 강제 풀 빌드 가능
- `.cache/` `.gitignore` 추가

## Why
빌드할 때마다 모든 포스트의 블록을 Notion API에서 재귀적으로 가져와 빌드 시간이 길어지는 문제를 해결합니다. 글 1개만 수정해도 50개 포스트를 모두 다시 받아야 했지만, 이제 변경된 페이지만 API를 호출합니다.

## 구현 디테일
- 캐시 키: `pageId` + `last_edited_time` 일치 시에만 캐시 사용
- 캐시 미스/stale 시 자동으로 API 재호출 후 재저장
- 파싱 실패한 캐시 파일은 자동 무효화
- CI에서는 \`actions/cache\`로 \`.cache/notion\`을 복원하면 효과 유지

## Test plan
- [x] \`tsc --noEmit\` 통과
- [x] 캐시 read/write/stale 무효화 스모크 테스트 통과
- [ ] 로컬 풀 빌드 1회 → 재빌드 시 API 호출 수 감소 확인
- [ ] \`NOTION_CACHE_DISABLED=true pnpm build\`로 캐시 우회 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)