### PR TITLE
fix: Vercel 서버리스 캐시 쓰기 실패로 인한 404 수정

### DIFF
--- a/src/features/notion/service/notion-cache.ts
+++ b/src/features/notion/service/notion-cache.ts
@@ -88,14 +88,18 @@ export function writePageBlocksCache(pageId: string, lastEditedTime: string, blo
   const ctx = getCachePaths();
   if (!ctx) return;
 
-  if (!ctx.fs.existsSync(ctx.pagesDir)) {
-    ctx.fs.mkdirSync(ctx.pagesDir, { recursive: true });
-  }
-  const cachePath = getPageCachePath(pageId);
-  if (!cachePath) return;
+  try {
+    if (!ctx.fs.existsSync(ctx.pagesDir)) {
+      ctx.fs.mkdirSync(ctx.pagesDir, { recursive: true });
+    }
+    const cachePath = getPageCachePath(pageId);
+    if (!cachePath) return;
 
-  const entry: PageBlocksCacheEntry = { lastEditedTime, blocks };
-  ctx.fs.writeFileSync(cachePath, JSON.stringify(entry));
+    const entry: PageBlocksCacheEntry = { lastEditedTime, blocks };
+    ctx.fs.writeFileSync(cachePath, JSON.stringify(entry));
+  } catch {
+    // Vercel 서버리스 등 읽기 전용 파일시스템에서는 조용히 무시
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- `writePageBlocksCache`에 try/catch 추가
- Vercel 서버리스 런타임(읽기 전용 파일시스템)에서 캐시 쓰기 시 throw → 페이지 렌더링 실패 → 전체 포스트 404 발생하던 문제 수정

## 원인
ISR 재검증 시 `fs.mkdirSync`/`fs.writeFileSync`가 `/var/task/`(읽기 전용)에 쓰려다 uncaught throw 발생

## Test plan
- [x] `tsc --noEmit` 통과
- [ ] Vercel 배포 후 포스트 페이지 404 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)