### PR TITLE
style: 블로그 본문 간격 조정

### DIFF
--- a/src/app/ClientLayout.tsx
+++ b/src/app/ClientLayout.tsx
@@ -28,7 +28,7 @@ export function ClientLayout({ children }: ClientLayoutProps) {
   return (
     <>
       <Header plugins={headerPlugins} mobilePlugins={mobileHeaderPlugins} />
-      <main id="main-content" className="flex-1 max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 w-full" tabIndex={-1}>
+      <main id="main-content" className="flex-1 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 w-full" tabIndex={-1}>
         {children}
       </main>
     </>

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -295,7 +295,7 @@ export default async function PostPage({ params }: PostPageProps) {
                 </div>
 
                 {post.excerpt && (
-                  <p className="border-l-2 border-primary-500 pl-4 text-lg leading-7 text-gray-600 dark:border-primary-400 dark:text-gray-300">
+                  <p className="mb-8 border-l-2 border-primary-500 pl-4 text-lg leading-7 text-gray-600 dark:border-primary-400 dark:text-gray-300">
                     {post.excerpt}
                   </p>
                 )}

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -267,7 +267,7 @@ export default async function PostPage({ params }: PostPageProps) {
         <ScrollProgress />
         <div className="py-10">
           <div className="mx-auto w-full">
-            <article className="mx-auto max-w-3xl">
+            <article className="mx-auto max-w-4xl">
               <header className="mx-auto mb-6 max-w-3xl">
                 <h1 className="mb-6 text-3xl leading-tight font-bold tracking-tight text-gray-950 md:text-4xl dark:text-gray-50">
                   {post.title}
@@ -303,7 +303,7 @@ export default async function PostPage({ params }: PostPageProps) {
 
               <PostContent
                 blocks={post.content}
-                className="mx-auto max-w-2xl text-[1.0625rem] leading-7 text-gray-800 dark:text-gray-200"
+                className="mx-auto max-w-3xl text-[1.0625rem] leading-[1.5] text-gray-800 dark:text-gray-200"
               />
 
               <footer className="mx-auto mt-16 max-w-3xl pt-8">

--- a/src/features/notion/ui/ContentBlockRenderer.tsx
+++ b/src/features/notion/ui/ContentBlockRenderer.tsx
@@ -24,7 +24,7 @@ export function ContentBlockRenderer({
   switch (block.type) {
     case "text":
       return (
-        <p className="my-2.5 leading-[1.75]">
+        <p className="my-5 leading-[1.5]">
           {block.richText && block.richText.length > 0 ? (
             <RichTextRenderer items={block.richText} />
           ) : (
@@ -66,7 +66,7 @@ export function ContentBlockRenderer({
 
     case "quote":
       return (
-        <blockquote className="my-5 border-l-2 border-gray-300 bg-gray-50 px-6 py-3 italic text-gray-700 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300">
+        <blockquote className="my-5 border-l-2 border-gray-300 bg-gray-50 px-6 py-3 leading-[1.5] italic text-gray-700 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300">
           {block.richText && block.richText.length > 0 ? (
             <RichTextRenderer items={block.richText} />
           ) : (
@@ -87,7 +87,7 @@ export function ContentBlockRenderer({
 
     case "list_item":
       return (
-        <li className="my-1">
+        <li className="my-5 leading-[1.5]">
           {block.richText && block.richText.length > 0 ? (
             <RichTextRenderer items={block.richText} />
           ) : (


### PR DESCRIPTION
## Changes

- 포스트 본문과 페이지 래퍼의 최대 너비를 넓혀 좌우 여백을 줄임
- 텍스트, 인용문, 리스트 블록의 줄간격을 1.5로 조정
- 텍스트 블록 간 세로 여백을 20px 수준으로 조정

## Testing

- pnpm lint
- pnpm typecheck
- 로컬 미리보기 스크린샷으로 본문 폭, 블록 여백, line-height 확인