### PR TITLE
style: 헤더 너비를 본문 레이아웃에 맞춤

### DIFF
--- a/src/shared/ui/Header/Header.tsx
+++ b/src/shared/ui/Header/Header.tsx
@@ -28,7 +28,7 @@ export function Header({ plugins, mobilePlugins = [], className }: HeaderProps) 
 
   return (
     <header className={cn("border-b border-gray-200 dark:border-dark-border", className)}>
-      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* 좌측 섹션 */}
           <div className="flex items-center gap-4">


### PR DESCRIPTION
## Changes

- 상단 헤더 컨테이너의 최대 너비를 본문 레이아웃과 동일하게 조정
- 본문 폭 확장 후 헤더와 콘텐츠의 좌우 정렬이 어긋나 보이는 문제를 보정

## Testing

- pnpm lint
- pnpm typecheck