### PR TITLE
style: 홈 포스트 리스트 디자인 개선

### DIFF
--- a/src/app/ClientLayout.tsx
+++ b/src/app/ClientLayout.tsx
@@ -28,7 +28,7 @@ export function ClientLayout({ children }: ClientLayoutProps) {
   return (
     <>
       <Header plugins={headerPlugins} mobilePlugins={mobileHeaderPlugins} />
-      <main id="main-content" className="flex-1 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 w-full" tabIndex={-1}>
+      <main id="main-content" className="flex-1 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 w-full" tabIndex={-1}>
         {children}
       </main>
     </>

--- a/src/app/ClientLayout.tsx
+++ b/src/app/ClientLayout.tsx
@@ -28,7 +28,7 @@ export function ClientLayout({ children }: ClientLayoutProps) {
   return (
     <>
       <Header plugins={headerPlugins} mobilePlugins={mobileHeaderPlugins} />
-      <main id="main-content" className="flex-1 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 w-full" tabIndex={-1}>
+      <main id="main-content" className="flex-1 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 w-full" tabIndex={-1}>
         {children}
       </main>
     </>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -130,7 +130,7 @@ export default async function RootLayout({
   return (
     <html lang="ko" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col bg-[#fdfbf8] dark:bg-dark-bg`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col bg-white dark:bg-dark-bg`}
       >
         <a
           href="#main-content"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -130,7 +130,7 @@ export default async function RootLayout({
   return (
     <html lang="ko" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col bg-[#fbf8f3] dark:bg-dark-bg`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col bg-[#fdfbf8] dark:bg-dark-bg`}
       >
         <a
           href="#main-content"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -130,7 +130,7 @@ export default async function RootLayout({
   return (
     <html lang="ko" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col bg-white dark:bg-dark-bg`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col bg-[#fbf8f3] dark:bg-dark-bg`}
       >
         <a
           href="#main-content"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,7 +43,7 @@ export default async function Home() {
   return (
     <div className="text-gray-900 dark:text-white">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }} />
-      <div className="py-8">
+      <div className="pt-3 pb-8 sm:pt-4">
         {/* 클라이언트 컴포넌트로 전체 포스트 전달 */}
         <PostList posts={sortedPosts} postsPerPage={POSTS_PER_PAGE} />
       </div>

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -303,7 +303,7 @@ export default async function PostPage({ params }: PostPageProps) {
 
               <PostContent
                 blocks={post.content}
-                className="mx-auto max-w-5xl text-[1.0625rem] leading-[1.5] text-gray-800 dark:text-gray-200"
+                className="mx-auto max-w-5xl text-[1.0625rem] leading-[1.75] text-gray-800 dark:text-gray-200"
               />
 
               <footer className="mx-auto mt-16 max-w-5xl pt-8">

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -267,8 +267,8 @@ export default async function PostPage({ params }: PostPageProps) {
         <ScrollProgress />
         <div className="py-10">
           <div className="mx-auto w-full">
-            <article className="mx-auto max-w-4xl">
-              <header className="mx-auto mb-6 max-w-3xl">
+            <article className="mx-auto max-w-5xl">
+              <header className="mx-auto mb-6 max-w-5xl">
                 <h1 className="mb-6 text-3xl leading-tight font-bold tracking-tight text-gray-950 md:text-4xl dark:text-gray-50">
                   {post.title}
                 </h1>
@@ -303,10 +303,10 @@ export default async function PostPage({ params }: PostPageProps) {
 
               <PostContent
                 blocks={post.content}
-                className="mx-auto max-w-3xl text-[1.0625rem] leading-[1.5] text-gray-800 dark:text-gray-200"
+                className="mx-auto max-w-5xl text-[1.0625rem] leading-[1.5] text-gray-800 dark:text-gray-200"
               />
 
-              <footer className="mx-auto mt-16 max-w-3xl pt-8">
+              <footer className="mx-auto mt-16 max-w-5xl pt-8">
                 <PostNavigation previousPost={previousPost} nextPost={nextPost} />
 
                 <div className="mt-12 border-t border-gray-200 pt-8 dark:border-gray-800">

--- a/src/entities/post/ui/PostCard.tsx
+++ b/src/entities/post/ui/PostCard.tsx
@@ -91,7 +91,7 @@ export function PostCard({ post }: PostCardProps) {
               {post.tags.map((tag) => (
                 <span
                   key={tag.slug}
-                  className="rounded-md bg-[#efe8dc] px-2.5 py-1 text-xs font-medium text-[#6f6253] sm:px-3 sm:py-1.5 sm:text-sm dark:bg-gray-800 dark:text-gray-400"
+                  className="rounded-md bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-500 sm:px-3 sm:py-1.5 sm:text-sm dark:bg-gray-800 dark:text-gray-400"
                 >
                   #{tag.name}
                 </span>

--- a/src/entities/post/ui/PostCard.tsx
+++ b/src/entities/post/ui/PostCard.tsx
@@ -45,14 +45,14 @@ export function PostCard({ post }: PostCardProps) {
   const thumbnailCaption = post.tags.slice(0, 2).map((tag) => tag.slug || tag.name).join(" · ");
 
   return (
-    <article className="border-b border-gray-200 py-12 dark:border-gray-800">
-      <div className="grid gap-8 md:grid-cols-[minmax(0,1fr)_176px] md:items-center lg:grid-cols-[minmax(0,1fr)_220px]">
+    <article className="border-b border-gray-200 py-8 dark:border-gray-800">
+      <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_148px] md:items-center lg:grid-cols-[minmax(0,1fr)_180px]">
         <div className="min-w-0">
-          <time dateTime={post.publishedAt.toISOString()} className="mb-4 block text-lg font-semibold text-gray-400 dark:text-gray-500">
+          <time dateTime={post.publishedAt.toISOString()} className="mb-3 block text-base font-semibold text-gray-400 dark:text-gray-500">
             {formatDate(post.publishedAt)}
           </time>
 
-          <h2 className="mb-4 text-3xl font-bold leading-tight text-gray-950 dark:text-gray-50">
+          <h2 className="mb-3 text-2xl font-bold leading-tight text-gray-950 dark:text-gray-50">
             <Link
               href={`/posts/${post.slug}`}
               className="hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
@@ -61,14 +61,14 @@ export function PostCard({ post }: PostCardProps) {
             </Link>
           </h2>
 
-          {post.excerpt && <p className="mb-6 text-xl leading-[1.5] text-gray-500 line-clamp-2 dark:text-gray-400">{post.excerpt}</p>}
+          {post.excerpt && <p className="mb-5 text-lg leading-[1.5] text-gray-500 line-clamp-2 dark:text-gray-400">{post.excerpt}</p>}
 
           {post.tags.length > 0 && (
-            <div className="flex flex-wrap gap-3">
+            <div className="flex flex-wrap gap-2.5">
               {post.tags.map((tag) => (
                 <span
                   key={tag.slug}
-                  className="rounded-md bg-gray-100 px-3 py-1.5 text-base font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+                  className="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
                 >
                   #{tag.name}
                 </span>
@@ -87,14 +87,14 @@ export function PostCard({ post }: PostCardProps) {
               src={post.coverImage}
               alt=""
               fill
-              sizes="(max-width: 1024px) 176px, 220px"
+              sizes="(max-width: 1024px) 148px, 180px"
               className="object-cover transition-transform duration-300 hover:scale-105"
             />
           ) : (
-            <div className={`flex h-full w-full flex-col justify-between p-5 ${thumbnailTheme.surface}`}>
-              <span className={`text-4xl font-black leading-none ${thumbnailTheme.mark}`}>{thumbnailTheme.symbol}</span>
+            <div className={`flex h-full w-full flex-col justify-between p-4 ${thumbnailTheme.surface}`}>
+              <span className={`text-3xl font-black leading-none ${thumbnailTheme.mark}`}>{thumbnailTheme.symbol}</span>
               {thumbnailCaption && (
-                <span className={`truncate font-mono text-sm font-semibold ${thumbnailTheme.caption}`}>{thumbnailCaption}</span>
+                <span className={`truncate font-mono text-xs font-semibold ${thumbnailTheme.caption}`}>{thumbnailCaption}</span>
               )}
             </div>
           )}

--- a/src/entities/post/ui/PostCard.tsx
+++ b/src/entities/post/ui/PostCard.tsx
@@ -1,17 +1,58 @@
 import Link from "next/link";
+import Image from "next/image";
 import type { PostMetadata } from "../model/usePostsQuery";
 
 interface PostCardProps {
   post: PostMetadata;
 }
 
-// test
+const thumbnailThemes = [
+  {
+    surface: "bg-[#e8edf5] dark:bg-[#1f2937]",
+    mark: "text-[#36577e] dark:text-[#93b4df]",
+    caption: "text-[#8292aa] dark:text-[#9caec7]",
+    symbol: "?",
+  },
+  {
+    surface: "bg-[#e8f1ec] dark:bg-[#17251d]",
+    mark: "text-primary-700 dark:text-primary-300",
+    caption: "text-primary-700/60 dark:text-primary-200/70",
+    symbol: "</>",
+  },
+  {
+    surface: "bg-[#f1eee8] dark:bg-[#2a241c]",
+    mark: "text-[#755f3a] dark:text-[#d6bd8c]",
+    caption: "text-[#8b7b62] dark:text-[#d0b98a]",
+    symbol: "#",
+  },
+];
+
+function getThumbnailTheme(post: PostMetadata) {
+  const source = post.tags[0]?.name || post.title;
+  const charSum = Array.from(source).reduce((sum, char) => sum + char.charCodeAt(0), 0);
+  return thumbnailThemes[charSum % thumbnailThemes.length];
+}
+
+function formatDate(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}.${month}.${day}`;
+}
+
 export function PostCard({ post }: PostCardProps) {
+  const thumbnailTheme = getThumbnailTheme(post);
+  const thumbnailCaption = post.tags.slice(0, 2).map((tag) => tag.slug || tag.name).join(" · ");
+
   return (
-    <article className="py-4 border-b border-gray-200 dark:border-gray-700 last:border-b-0">
-      <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-2">
-        <div className="flex-1">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
+    <article className="border-b border-gray-200 py-12 dark:border-gray-800">
+      <div className="grid gap-8 md:grid-cols-[minmax(0,1fr)_176px] md:items-center lg:grid-cols-[minmax(0,1fr)_220px]">
+        <div className="min-w-0">
+          <time dateTime={post.publishedAt.toISOString()} className="mb-4 block text-lg font-semibold text-gray-400 dark:text-gray-500">
+            {formatDate(post.publishedAt)}
+          </time>
+
+          <h2 className="mb-4 text-3xl font-bold leading-tight text-gray-950 dark:text-gray-50">
             <Link
               href={`/posts/${post.slug}`}
               className="hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
@@ -20,24 +61,14 @@ export function PostCard({ post }: PostCardProps) {
             </Link>
           </h2>
 
-          {post.excerpt && <p className="text-gray-600 dark:text-gray-300 text-sm mb-2 line-clamp-2">{post.excerpt}</p>}
+          {post.excerpt && <p className="mb-6 text-xl leading-[1.5] text-gray-500 line-clamp-2 dark:text-gray-400">{post.excerpt}</p>}
 
-        </div>
-
-        <div className="md:ml-4 md:flex-shrink-0">
-          <time dateTime={post.publishedAt.toISOString()} className="text-xs text-gray-500 dark:text-gray-400">
-            {post.publishedAt.toLocaleDateString("ko-KR", {
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-            })}
-          </time>
           {post.tags.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-2 text-xs text-gray-500 dark:text-gray-400 md:max-w-[220px] md:justify-end">
+            <div className="flex flex-wrap gap-3">
               {post.tags.map((tag) => (
                 <span
                   key={tag.slug}
-                  className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded"
+                  className="rounded-md bg-gray-100 px-3 py-1.5 text-base font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
                 >
                   #{tag.name}
                 </span>
@@ -45,6 +76,29 @@ export function PostCard({ post }: PostCardProps) {
             </div>
           )}
         </div>
+
+        <Link
+          href={`/posts/${post.slug}`}
+          className="relative hidden aspect-[4/3] w-full overflow-hidden rounded-lg md:block"
+          aria-label={`${post.title} 포스트 보기`}
+        >
+          {post.coverImage ? (
+            <Image
+              src={post.coverImage}
+              alt=""
+              fill
+              sizes="(max-width: 1024px) 176px, 220px"
+              className="object-cover transition-transform duration-300 hover:scale-105"
+            />
+          ) : (
+            <div className={`flex h-full w-full flex-col justify-between p-5 ${thumbnailTheme.surface}`}>
+              <span className={`text-4xl font-black leading-none ${thumbnailTheme.mark}`}>{thumbnailTheme.symbol}</span>
+              {thumbnailCaption && (
+                <span className={`truncate font-mono text-sm font-semibold ${thumbnailTheme.caption}`}>{thumbnailCaption}</span>
+              )}
+            </div>
+          )}
+        </Link>
       </div>
     </article>
   );

--- a/src/entities/post/ui/PostCard.tsx
+++ b/src/entities/post/ui/PostCard.tsx
@@ -68,7 +68,7 @@ export function PostCard({ post }: PostCardProps) {
               {post.tags.map((tag) => (
                 <span
                   key={tag.slug}
-                  className="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+                  className="rounded-md bg-[#efe8dc] px-3 py-1.5 text-sm font-medium text-[#6f6253] dark:bg-gray-800 dark:text-gray-400"
                 >
                   #{tag.name}
                 </span>

--- a/src/entities/post/ui/PostCard.tsx
+++ b/src/entities/post/ui/PostCard.tsx
@@ -46,10 +46,10 @@ export function PostCard({ post }: PostCardProps) {
 
   return (
     <article className="border-b border-gray-200 py-7 dark:border-gray-800">
-      <div className="grid grid-cols-[112px_minmax(0,1fr)] items-center gap-4 sm:grid-cols-[132px_minmax(0,1fr)] sm:gap-5 md:grid-cols-[minmax(0,1fr)_148px] lg:grid-cols-[minmax(0,1fr)_180px]">
+      <div className="grid grid-cols-[112px_minmax(0,1fr)] items-center gap-4 sm:grid-cols-[132px_minmax(0,1fr)] sm:gap-5 md:grid-cols-[148px_minmax(0,1fr)] lg:grid-cols-[minmax(0,1fr)_180px]">
         <Link
           href={`/posts/${post.slug}`}
-          className="relative aspect-[4/3] w-full overflow-hidden rounded-lg md:order-2"
+          className="relative aspect-[4/3] w-full overflow-hidden rounded-lg lg:order-2"
           aria-label={`${post.title} 포스트 보기`}
         >
           {post.coverImage ? (
@@ -70,7 +70,7 @@ export function PostCard({ post }: PostCardProps) {
           )}
         </Link>
 
-        <div className="min-w-0 md:order-1">
+        <div className="min-w-0 lg:order-1">
           <time dateTime={post.publishedAt.toISOString()} className="mb-2 block text-sm font-semibold text-gray-400 sm:text-base dark:text-gray-500">
             {formatDate(post.publishedAt)}
           </time>

--- a/src/entities/post/ui/PostCard.tsx
+++ b/src/entities/post/ui/PostCard.tsx
@@ -45,14 +45,37 @@ export function PostCard({ post }: PostCardProps) {
   const thumbnailCaption = post.tags.slice(0, 2).map((tag) => tag.slug || tag.name).join(" · ");
 
   return (
-    <article className="border-b border-gray-200 py-8 dark:border-gray-800">
-      <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_148px] md:items-center lg:grid-cols-[minmax(0,1fr)_180px]">
+    <article className="border-b border-gray-200 py-7 dark:border-gray-800">
+      <div className="grid grid-cols-[112px_minmax(0,1fr)] items-center gap-4 sm:grid-cols-[132px_minmax(0,1fr)] sm:gap-5 md:grid-cols-[148px_minmax(0,1fr)] lg:grid-cols-[180px_minmax(0,1fr)]">
+        <Link
+          href={`/posts/${post.slug}`}
+          className="relative aspect-[4/3] w-full overflow-hidden rounded-lg"
+          aria-label={`${post.title} 포스트 보기`}
+        >
+          {post.coverImage ? (
+            <Image
+              src={post.coverImage}
+              alt=""
+              fill
+              sizes="(max-width: 640px) 112px, (max-width: 768px) 132px, (max-width: 1024px) 148px, 180px"
+              className="object-cover transition-transform duration-300 hover:scale-105"
+            />
+          ) : (
+            <div className={`flex h-full w-full flex-col justify-between p-3 sm:p-4 ${thumbnailTheme.surface}`}>
+              <span className={`text-2xl font-black leading-none sm:text-3xl ${thumbnailTheme.mark}`}>{thumbnailTheme.symbol}</span>
+              {thumbnailCaption && (
+                <span className={`truncate font-mono text-[10px] font-semibold sm:text-xs ${thumbnailTheme.caption}`}>{thumbnailCaption}</span>
+              )}
+            </div>
+          )}
+        </Link>
+
         <div className="min-w-0">
-          <time dateTime={post.publishedAt.toISOString()} className="mb-3 block text-base font-semibold text-gray-400 dark:text-gray-500">
+          <time dateTime={post.publishedAt.toISOString()} className="mb-2 block text-sm font-semibold text-gray-400 sm:text-base dark:text-gray-500">
             {formatDate(post.publishedAt)}
           </time>
 
-          <h2 className="mb-3 text-2xl font-bold leading-tight text-gray-950 dark:text-gray-50">
+          <h2 className="mb-2 text-xl font-bold leading-tight text-gray-950 sm:text-2xl dark:text-gray-50">
             <Link
               href={`/posts/${post.slug}`}
               className="hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
@@ -61,14 +84,14 @@ export function PostCard({ post }: PostCardProps) {
             </Link>
           </h2>
 
-          {post.excerpt && <p className="mb-5 text-lg leading-[1.5] text-gray-500 line-clamp-2 dark:text-gray-400">{post.excerpt}</p>}
+          {post.excerpt && <p className="mb-4 text-base leading-[1.5] text-gray-500 line-clamp-2 sm:text-lg dark:text-gray-400">{post.excerpt}</p>}
 
           {post.tags.length > 0 && (
-            <div className="flex flex-wrap gap-2.5">
+            <div className="flex flex-wrap gap-2">
               {post.tags.map((tag) => (
                 <span
                   key={tag.slug}
-                  className="rounded-md bg-[#efe8dc] px-3 py-1.5 text-sm font-medium text-[#6f6253] dark:bg-gray-800 dark:text-gray-400"
+                  className="rounded-md bg-[#efe8dc] px-2.5 py-1 text-xs font-medium text-[#6f6253] sm:px-3 sm:py-1.5 sm:text-sm dark:bg-gray-800 dark:text-gray-400"
                 >
                   #{tag.name}
                 </span>
@@ -76,29 +99,6 @@ export function PostCard({ post }: PostCardProps) {
             </div>
           )}
         </div>
-
-        <Link
-          href={`/posts/${post.slug}`}
-          className="relative hidden aspect-[4/3] w-full overflow-hidden rounded-lg md:block"
-          aria-label={`${post.title} 포스트 보기`}
-        >
-          {post.coverImage ? (
-            <Image
-              src={post.coverImage}
-              alt=""
-              fill
-              sizes="(max-width: 1024px) 148px, 180px"
-              className="object-cover transition-transform duration-300 hover:scale-105"
-            />
-          ) : (
-            <div className={`flex h-full w-full flex-col justify-between p-4 ${thumbnailTheme.surface}`}>
-              <span className={`text-3xl font-black leading-none ${thumbnailTheme.mark}`}>{thumbnailTheme.symbol}</span>
-              {thumbnailCaption && (
-                <span className={`truncate font-mono text-xs font-semibold ${thumbnailTheme.caption}`}>{thumbnailCaption}</span>
-              )}
-            </div>
-          )}
-        </Link>
       </div>
     </article>
   );

--- a/src/entities/post/ui/PostCard.tsx
+++ b/src/entities/post/ui/PostCard.tsx
@@ -46,10 +46,10 @@ export function PostCard({ post }: PostCardProps) {
 
   return (
     <article className="border-b border-gray-200 py-7 dark:border-gray-800">
-      <div className="grid grid-cols-[112px_minmax(0,1fr)] items-center gap-4 sm:grid-cols-[132px_minmax(0,1fr)] sm:gap-5 md:grid-cols-[148px_minmax(0,1fr)] lg:grid-cols-[180px_minmax(0,1fr)]">
+      <div className="grid grid-cols-[112px_minmax(0,1fr)] items-center gap-4 sm:grid-cols-[132px_minmax(0,1fr)] sm:gap-5 md:grid-cols-[minmax(0,1fr)_148px] lg:grid-cols-[minmax(0,1fr)_180px]">
         <Link
           href={`/posts/${post.slug}`}
-          className="relative aspect-[4/3] w-full overflow-hidden rounded-lg"
+          className="relative aspect-[4/3] w-full overflow-hidden rounded-lg md:order-2"
           aria-label={`${post.title} 포스트 보기`}
         >
           {post.coverImage ? (
@@ -70,7 +70,7 @@ export function PostCard({ post }: PostCardProps) {
           )}
         </Link>
 
-        <div className="min-w-0">
+        <div className="min-w-0 md:order-1">
           <time dateTime={post.publishedAt.toISOString()} className="mb-2 block text-sm font-semibold text-gray-400 sm:text-base dark:text-gray-500">
             {formatDate(post.publishedAt)}
           </time>

--- a/src/entities/post/ui/PostList.tsx
+++ b/src/entities/post/ui/PostList.tsx
@@ -15,7 +15,7 @@ const getButtonClassName = (isActive: boolean) => {
   if (isActive) {
     return `${baseClasses} bg-primary-600 text-white hover:bg-primary-700`;
   }
-  return `${baseClasses} bg-[#efe8dc] text-[#6f6253] hover:bg-[#e7dece] dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700`;
+  return `${baseClasses} bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700`;
 };
 
 export function PostList({ posts, postsPerPage }: PostListProps) {

--- a/src/entities/post/ui/PostList.tsx
+++ b/src/entities/post/ui/PostList.tsx
@@ -15,7 +15,7 @@ const getButtonClassName = (isActive: boolean) => {
   if (isActive) {
     return `${baseClasses} bg-primary-600 text-white hover:bg-primary-700`;
   }
-  return `${baseClasses} bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700`;
+  return `${baseClasses} bg-[#efe8dc] text-[#6f6253] hover:bg-[#e7dece] dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700`;
 };
 
 export function PostList({ posts, postsPerPage }: PostListProps) {

--- a/src/entities/post/ui/PostList.tsx
+++ b/src/entities/post/ui/PostList.tsx
@@ -11,7 +11,7 @@ interface PostListProps {
 
 // 태그 버튼 스타일 헬퍼
 const getButtonClassName = (isActive: boolean) => {
-  const baseClasses = "px-6 py-3 rounded-full text-base font-semibold transition-colors cursor-pointer";
+  const baseClasses = "px-5 py-2.5 rounded-full text-sm font-semibold transition-colors cursor-pointer";
   if (isActive) {
     return `${baseClasses} bg-primary-600 text-white hover:bg-primary-700`;
   }
@@ -105,8 +105,8 @@ export function PostList({ posts, postsPerPage }: PostListProps) {
   return (
     <>
       {/* 태그 필터 */}
-      <div className="pt-14 pb-12">
-        <div className="flex flex-wrap gap-4">
+      <div className="pt-7 pb-8">
+        <div className="flex flex-wrap gap-3">
           <button onClick={() => handleTagClick(null)} className={getButtonClassName(selectedTag === null)}>
             전체 ({posts.length})
           </button>

--- a/src/entities/post/ui/PostList.tsx
+++ b/src/entities/post/ui/PostList.tsx
@@ -11,11 +11,11 @@ interface PostListProps {
 
 // 태그 버튼 스타일 헬퍼
 const getButtonClassName = (isActive: boolean) => {
-  const baseClasses = "px-4 py-2 rounded-full text-sm font-medium transition-colors cursor-pointer";
+  const baseClasses = "px-6 py-3 rounded-full text-base font-semibold transition-colors cursor-pointer";
   if (isActive) {
     return `${baseClasses} bg-primary-600 text-white hover:bg-primary-700`;
   }
-  return `${baseClasses} bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700`;
+  return `${baseClasses} bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700`;
 };
 
 export function PostList({ posts, postsPerPage }: PostListProps) {
@@ -105,8 +105,8 @@ export function PostList({ posts, postsPerPage }: PostListProps) {
   return (
     <>
       {/* 태그 필터 */}
-      <div className="mb-8">
-        <div className="flex flex-wrap gap-2">
+      <div className="pt-14 pb-12">
+        <div className="flex flex-wrap gap-4">
           <button onClick={() => handleTagClick(null)} className={getButtonClassName(selectedTag === null)}>
             전체 ({posts.length})
           </button>
@@ -121,7 +121,7 @@ export function PostList({ posts, postsPerPage }: PostListProps) {
         </div>
       </div>
 
-      <div className="space-y-0 mb-8">
+      <div className="mb-10 border-t border-gray-200 dark:border-gray-800">
         {visiblePosts.map((post) => (
           <PostCard key={post.id} post={post} />
         ))}

--- a/src/entities/post/ui/PostList.tsx
+++ b/src/entities/post/ui/PostList.tsx
@@ -105,8 +105,8 @@ export function PostList({ posts, postsPerPage }: PostListProps) {
   return (
     <>
       {/* 태그 필터 */}
-      <div className="pt-7 pb-8">
-        <div className="flex flex-wrap gap-3">
+      <div className="pt-0 pb-5 sm:pb-7">
+        <div className="flex flex-wrap gap-2.5 sm:gap-3">
           <button onClick={() => handleTagClick(null)} className={getButtonClassName(selectedTag === null)}>
             전체 ({posts.length})
           </button>

--- a/src/features/notion/ui/ContentBlockRenderer.tsx
+++ b/src/features/notion/ui/ContentBlockRenderer.tsx
@@ -24,7 +24,7 @@ export function ContentBlockRenderer({
   switch (block.type) {
     case "text":
       return (
-        <p className="my-5 leading-[1.5]">
+        <p className="my-5 leading-[1.75]">
           {block.richText && block.richText.length > 0 ? (
             <RichTextRenderer items={block.richText} />
           ) : (
@@ -66,7 +66,7 @@ export function ContentBlockRenderer({
 
     case "quote":
       return (
-        <blockquote className="my-5 border-l-2 border-gray-300 bg-gray-50 px-6 py-3 leading-[1.5] italic text-gray-700 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300">
+        <blockquote className="my-5 border-l-2 border-gray-300 bg-gray-50 px-6 py-3 leading-[1.75] italic text-gray-700 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300">
           {block.richText && block.richText.length > 0 ? (
             <RichTextRenderer items={block.richText} />
           ) : (
@@ -87,7 +87,7 @@ export function ContentBlockRenderer({
 
     case "list_item":
       return (
-        <li className="my-5 leading-[1.5]">
+        <li className="my-5 leading-[1.75]">
           {block.richText && block.richText.length > 0 ? (
             <RichTextRenderer items={block.richText} />
           ) : (

--- a/src/shared/ui/Header/Header.tsx
+++ b/src/shared/ui/Header/Header.tsx
@@ -28,7 +28,7 @@ export function Header({ plugins, mobilePlugins = [], className }: HeaderProps) 
 
   return (
     <header className={cn("border-b border-gray-200 dark:border-dark-border", className)}>
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* 좌측 섹션 */}
           <div className="flex items-center gap-4">

--- a/src/shared/ui/Header/Header.tsx
+++ b/src/shared/ui/Header/Header.tsx
@@ -28,7 +28,7 @@ export function Header({ plugins, mobilePlugins = [], className }: HeaderProps) 
 
   return (
     <header className={cn("border-b border-gray-200 dark:border-dark-border", className)}>
-      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* 좌측 섹션 */}
           <div className="flex items-center gap-4">

--- a/src/shared/ui/Header/plugins/navigationPlugin.tsx
+++ b/src/shared/ui/Header/plugins/navigationPlugin.tsx
@@ -1,27 +1,35 @@
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { HeaderPlugin } from '../types';
+
+function NavigationLinks() {
+  const pathname = usePathname();
+  const isPostActive = pathname === "/" || pathname.startsWith("/posts");
+  const isAboutActive = pathname === "/about";
+
+  const getLinkClassName = (isActive: boolean) =>
+    `text-gray-700 dark:text-gray-300 hover:text-primary-600 dark:hover:text-primary-400 px-2 py-2 text-sm transition-colors ${
+      isActive ? "font-bold text-gray-950 dark:text-white" : "font-medium"
+    }`;
+
+  return (
+    <nav aria-label="주요 네비게이션" className="hidden md:flex items-center gap-5">
+      <Link href="/" className={getLinkClassName(isPostActive)}>
+        Post
+      </Link>
+      <Link href="/about" className={getLinkClassName(isAboutActive)}>
+        About
+      </Link>
+    </nav>
+  );
+}
 
 export function createNavigationPlugin(): HeaderPlugin {
   return {
     id: 'navigation',
     name: '네비게이션',
-    position: 'center',
+    position: 'right',
     priority: 10,
-    render: () => (
-      <nav aria-label="주요 네비게이션" className="hidden md:flex items-center space-x-8">
-        <Link
-          href="/"
-          className="text-gray-700 dark:text-gray-300 hover:text-primary-600 dark:hover:text-primary-400 px-3 py-2 text-sm font-medium transition-colors"
-        >
-          Post
-        </Link>
-        <Link
-          href="/about"
-          className="text-gray-700 dark:text-gray-300 hover:text-primary-600 dark:hover:text-primary-400 px-3 py-2 text-sm font-medium transition-colors"
-        >
-          About
-        </Link>
-      </nav>
-    ),
+    render: () => <NavigationLinks />,
   };
 }

--- a/src/shared/ui/Header/plugins/navigationPlugin.tsx
+++ b/src/shared/ui/Header/plugins/navigationPlugin.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { HeaderPlugin } from '../types';


### PR DESCRIPTION
## Changes

- 홈 화면 포스트 리스트를 넓은 리스트형 레이아웃으로 재구성
- 태그 필터 버튼을 큰 pill 스타일로 조정
- 포스트 카드에 날짜, 큰 제목, 요약, 태그, 오른쪽 썸네일 영역을 배치
- 커버 이미지가 없는 포스트에 태그 기반 placeholder 썸네일을 표시
- 홈/헤더 레이아웃 폭을 넓은 리스트 디자인에 맞게 확장

## Testing

- pnpm lint
- pnpm typecheck