### PR TITLE
feat: 포스트 썸네일 이미지 우선순위 적용

### DIFF
--- a/src/entities/post/api/index.ts
+++ b/src/entities/post/api/index.ts
@@ -24,7 +24,7 @@ import type { BlogPost } from "../model";
  * 모든 포스트 목록을 조회합니다.
  */
 export async function getAllPosts(): Promise<
-  Pick<BlogPost, "id" | "title" | "slug" | "publishedAt" | "updatedAt" | "excerpt" | "tags" | "coverImage">[]
+  Pick<BlogPost, "id" | "title" | "slug" | "publishedAt" | "updatedAt" | "excerpt" | "tags" | "coverImage" | "thumbnailImage">[]
 > {
   const adapter = getPostApiAdapter();
   return adapter.getAllPosts();

--- a/src/entities/post/api/types.ts
+++ b/src/entities/post/api/types.ts
@@ -12,7 +12,7 @@ export interface PostApi {
    * @returns 포스트 목록 (메타데이터만 포함)
    */
   getAllPosts(): Promise<
-    Pick<BlogPost, "id" | "title" | "slug" | "publishedAt" | "updatedAt" | "excerpt" | "tags" | "coverImage">[]
+    Pick<BlogPost, "id" | "title" | "slug" | "publishedAt" | "updatedAt" | "excerpt" | "tags" | "coverImage" | "thumbnailImage">[]
   >;
 
   /**

--- a/src/entities/post/model/index.ts
+++ b/src/entities/post/model/index.ts
@@ -15,6 +15,7 @@ export interface BlogPost {
   updatedAt: Date;
   tags: Tag[];
   coverImage?: string;
+  thumbnailImage?: string;
   toc: TableOfContentsItem[];
 }
 

--- a/src/entities/post/model/usePostsQuery.ts
+++ b/src/entities/post/model/usePostsQuery.ts
@@ -8,7 +8,7 @@ import type { BlogPost } from "./index";
  */
 export type PostMetadata = Pick<
   BlogPost,
-  "id" | "title" | "slug" | "publishedAt" | "updatedAt" | "excerpt" | "tags" | "coverImage"
+  "id" | "title" | "slug" | "publishedAt" | "updatedAt" | "excerpt" | "tags" | "coverImage" | "thumbnailImage"
 >;
 
 /**

--- a/src/entities/post/ui/PostCard.tsx
+++ b/src/entities/post/ui/PostCard.tsx
@@ -43,6 +43,7 @@ function formatDate(date: Date) {
 export function PostCard({ post }: PostCardProps) {
   const thumbnailTheme = getThumbnailTheme(post);
   const thumbnailCaption = post.tags.slice(0, 2).map((tag) => tag.slug || tag.name).join(" · ");
+  const thumbnailImage = post.thumbnailImage || post.coverImage;
 
   return (
     <article className="border-b border-gray-200 py-7 dark:border-gray-800">
@@ -52,9 +53,9 @@ export function PostCard({ post }: PostCardProps) {
           className="relative aspect-[4/3] w-full overflow-hidden rounded-lg lg:order-2"
           aria-label={`${post.title} 포스트 보기`}
         >
-          {post.coverImage ? (
+          {thumbnailImage ? (
             <Image
-              src={post.coverImage}
+              src={thumbnailImage}
               alt=""
               fill
               sizes="(max-width: 640px) 112px, (max-width: 768px) 132px, (max-width: 1024px) 148px, 180px"

--- a/src/features/notion/adapter/NotionPostAdapter.ts
+++ b/src/features/notion/adapter/NotionPostAdapter.ts
@@ -14,7 +14,7 @@ export class NotionPostAdapter implements PostApi {
    * NotionPost를 BlogPost 메타데이터로 변환합니다.
    */
   async getAllPosts(): Promise<
-    Pick<BlogPost, "id" | "title" | "slug" | "publishedAt" | "updatedAt" | "excerpt" | "tags" | "coverImage">[]
+    Pick<BlogPost, "id" | "title" | "slug" | "publishedAt" | "updatedAt" | "excerpt" | "tags" | "coverImage" | "thumbnailImage">[]
   > {
     const notionPosts = await notionGetAllPosts();
 
@@ -31,6 +31,7 @@ export class NotionPostAdapter implements PostApi {
         postCount: 0, // NotionPost에는 postCount가 없으므로 0으로 설정
       })),
       coverImage: post.coverImage,
+      thumbnailImage: post.thumbnailImage,
     }));
   }
 

--- a/src/features/notion/service/notion-client.ts
+++ b/src/features/notion/service/notion-client.ts
@@ -11,11 +11,13 @@ import type {
   NotionRichTextProperty,
   NotionMultiSelectProperty,
   NotionUrlProperty,
+  NotionFileProperty,
   NotionDateProperty,
   BlockContent,
 } from "../types";
 import type { BlogPost } from "@/entities/post/model";
 import { adaptNotionBlocksToContentBlocks } from "../utils/blockAdapter";
+import { getFirstImageFromContent } from "../utils/blockParser";
 import { readPageBlocksCache, writePageBlocksCache } from "./notion-cache";
 
 // Singleton client instance
@@ -84,8 +86,9 @@ export async function getAllPosts(): Promise<NotionPost[]> {
               const publishedAt = publishedAtDate || createdAt;
 
               // 커버 이미지 URL 처리 (S3 URL인 경우 공개 프록시 URL로 변환)
-              const rawCoverImage = getUrl(properties.coverImage);
+              const rawCoverImage = getImageUrl(properties.coverImage);
               const coverImage = rawCoverImage ? convertToPublicNotionImageUrl(rawCoverImage, notionPage.id) : undefined;
+              const thumbnailImage = await resolveThumbnailImage(notionPage, coverImage);
 
               return {
                 id: notionPage.id,
@@ -101,6 +104,7 @@ export async function getAllPosts(): Promise<NotionPost[]> {
                 })),
                 excerpt: getPlainText(properties.excerpt),
                 coverImage,
+                thumbnailImage,
               } as NotionPost;
             }
           }
@@ -180,8 +184,9 @@ export async function getPostByPageId(pageId: string, fetchContent = true): Prom
   const slug = `${baseSlug}-${pageIdWithoutHyphens}`;
 
   // 커버 이미지 URL 처리
-  const rawCoverImage = getUrl(properties.coverImage);
+  const rawCoverImage = getImageUrl(properties.coverImage);
   const coverImage = rawCoverImage ? convertToPublicNotionImageUrl(rawCoverImage, page.id) : undefined;
+  const thumbnailImage = await resolveThumbnailImage(page, coverImage, blocks);
 
   // NotionBlock을 공통 ContentBlock으로 변환
   const contentBlocks = adaptNotionBlocksToContentBlocks(blocks);
@@ -201,6 +206,7 @@ export async function getPostByPageId(pageId: string, fetchContent = true): Prom
       postCount: 0,
     })),
     coverImage,
+    thumbnailImage,
     toc: [],
   };
 }
@@ -283,7 +289,7 @@ function getMultiSelect(property: NotionPropertyValue | undefined): string[] {
   return [];
 }
 
-function getUrl(property: NotionPropertyValue | undefined): string | undefined {
+function getImageUrl(property: NotionPropertyValue | undefined): string | undefined {
   if (!property) return undefined;
 
   if (property.type === "url") {
@@ -291,7 +297,47 @@ function getUrl(property: NotionPropertyValue | undefined): string | undefined {
     return urlProp.url || undefined;
   }
 
+  if (property.type === "files") {
+    const fileProp = property as NotionFileProperty;
+    const firstFile = fileProp.files[0];
+    return firstFile?.external?.url || firstFile?.file?.url || undefined;
+  }
+
   return undefined;
+}
+
+function getPropertyByName(properties: NotionPage["properties"], names: string[]): NotionPropertyValue | undefined {
+  const normalizedNames = names.map((name) => name.toLowerCase());
+  const matchedEntry = Object.entries(properties).find(([name]) => normalizedNames.includes(name.toLowerCase()));
+  return matchedEntry?.[1];
+}
+
+async function resolveThumbnailImage(page: NotionPage, coverImage?: string, existingBlocks?: NotionBlock[]): Promise<string | undefined> {
+  const thumbnailProperty = getPropertyByName(page.properties, ["thumbnail", "thumnail"]);
+  const rawThumbnailImage = getImageUrl(thumbnailProperty);
+
+  if (rawThumbnailImage) {
+    return convertToPublicNotionImageUrl(rawThumbnailImage, page.id);
+  }
+
+  if (coverImage) {
+    return coverImage;
+  }
+
+  const blocks = existingBlocks ?? getCachedOrFreshPageBlocks(page);
+  const resolvedBlocks = Array.isArray(blocks) ? blocks : await blocks;
+  return getFirstImageFromContent(resolvedBlocks);
+}
+
+async function getCachedOrFreshPageBlocks(page: NotionPage): Promise<NotionBlock[]> {
+  const cached = readPageBlocksCache(page.id, page.last_edited_time);
+  if (cached) {
+    return cached;
+  }
+
+  const blocks = await getPostBlocks(page.id);
+  writePageBlocksCache(page.id, page.last_edited_time, blocks);
+  return blocks;
 }
 
 function getDate(property: NotionPropertyValue | undefined): string {

--- a/src/features/notion/types/index.ts
+++ b/src/features/notion/types/index.ts
@@ -13,6 +13,7 @@ export interface NotionPost {
   }>;
   excerpt?: string;
   coverImage?: string;
+  thumbnailImage?: string;
 }
 
 // Notion API 응답 타입들


### PR DESCRIPTION
## Changes

- 포스트 메타데이터에 `thumbnailImage` 필드를 추가
- Notion `coverImage` 속성에서 URL과 파일/미디어 타입 이미지를 모두 읽도록 확장
- `coverImage`가 없으면 콘텐츠 첫 번째 이미지 URL을 썸네일로 사용
- 이미지가 없을 때만 기존 fallback UI를 표시

## Testing

- pnpm lint
- pnpm typecheck