### PR TITLE
style: 리스트 아이템 간격 축소

### DIFF
--- a/src/features/notion/ui/ContentBlockRenderer.tsx
+++ b/src/features/notion/ui/ContentBlockRenderer.tsx
@@ -87,7 +87,7 @@ export function ContentBlockRenderer({
 
     case "list_item":
       return (
-        <li className="my-5 leading-[1.75]">
+        <li className="leading-[1.75]">
           {block.richText && block.richText.length > 0 ? (
             <RichTextRenderer items={block.richText} />
           ) : (


### PR DESCRIPTION
## Changes

- 포스트 본문 리스트 아이템의 큰 상하 마진 제거
- 리스트 그룹의 기존 `space-y-1` 간격만 적용되도록 조정

## Testing

- pnpm lint
- pnpm typecheck