### PR TITLE
fix: Notion API rate limit 대응

### DIFF
--- a/scripts/buildImages.ts
+++ b/scripts/buildImages.ts
@@ -82,14 +82,13 @@ async function main() {
     let newImageCount = 0;
     let skippedImageCount = 0;
 
-    // 병렬 처리: 모든 포스트의 이미지 URL을 동시에 추출
-    console.log("📥 모든 포스트의 이미지 URL을 병렬로 추출하는 중...\n");
-    const postImageData = await Promise.all(
-      posts.map(async (post) => {
-        const imageUrls = await extractPostImageUrls(post.id, post.slug, post.coverImage);
-        return { post, imageUrls };
-      })
-    );
+    // Notion API rate limit을 피하기 위해 포스트별 이미지 URL은 순차 추출
+    console.log("📥 모든 포스트의 이미지 URL을 추출하는 중...\n");
+    const postImageData: Array<{ post: (typeof posts)[number]; imageUrls: string[] }> = [];
+    for (const post of posts) {
+      const imageUrls = await extractPostImageUrls(post.id, post.slug, post.coverImage);
+      postImageData.push({ post, imageUrls });
+    }
 
     console.log("━".repeat(60));
 

--- a/scripts/buildImages.ts
+++ b/scripts/buildImages.ts
@@ -82,13 +82,14 @@ async function main() {
     let newImageCount = 0;
     let skippedImageCount = 0;
 
-    // Notion API rate limit을 피하기 위해 포스트별 이미지 URL은 순차 추출
-    console.log("📥 모든 포스트의 이미지 URL을 추출하는 중...\n");
-    const postImageData: Array<{ post: (typeof posts)[number]; imageUrls: string[] }> = [];
-    for (const post of posts) {
-      const imageUrls = await extractPostImageUrls(post.id, post.slug, post.coverImage);
-      postImageData.push({ post, imageUrls });
-    }
+    // Notion API 요청은 내부 큐에서 조율되므로 작업 자체는 병렬로 위임
+    console.log("📥 모든 포스트의 이미지 URL을 병렬로 추출하는 중...\n");
+    const postImageData = await Promise.all(
+      posts.map(async (post) => {
+        const imageUrls = await extractPostImageUrls(post.id, post.slug, post.coverImage);
+        return { post, imageUrls };
+      })
+    );
 
     console.log("━".repeat(60));
 

--- a/src/features/notion/service/notion-client.ts
+++ b/src/features/notion/service/notion-client.ts
@@ -22,6 +22,58 @@ import { readPageBlocksCache, writePageBlocksCache } from "./notion-cache";
 
 // Singleton client instance
 let client: Client | null = null;
+let lastNotionRequestAt = 0;
+
+const NOTION_MIN_REQUEST_INTERVAL_MS = 400;
+const NOTION_MAX_RETRY_COUNT = 5;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForNotionRequestSlot(): Promise<void> {
+  const now = Date.now();
+  const elapsed = now - lastNotionRequestAt;
+
+  if (elapsed < NOTION_MIN_REQUEST_INTERVAL_MS) {
+    await sleep(NOTION_MIN_REQUEST_INTERVAL_MS - elapsed);
+  }
+
+  lastNotionRequestAt = Date.now();
+}
+
+function isRateLimitError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const notionError = error as { status?: number; code?: string };
+  return notionError.status === 429 || notionError.code === "rate_limited";
+}
+
+function getRetryDelayMs(attempt: number): number {
+  return Math.min(1000 * 2 ** attempt, 10000);
+}
+
+async function runNotionRequest<T>(request: () => Promise<T>): Promise<T> {
+  for (let attempt = 0; attempt <= NOTION_MAX_RETRY_COUNT; attempt++) {
+    await waitForNotionRequestSlot();
+
+    try {
+      return await request();
+    } catch (error) {
+      if (!isRateLimitError(error) || attempt === NOTION_MAX_RETRY_COUNT) {
+        throw error;
+      }
+
+      const retryDelayMs = getRetryDelayMs(attempt);
+      console.warn(`Notion API rate limited. Retrying in ${retryDelayMs}ms...`);
+      await sleep(retryDelayMs);
+    }
+  }
+
+  throw new Error("Notion request retry loop exited unexpectedly");
+}
 
 function initialize() {
   if (client) return; // 이미 초기화됨
@@ -47,76 +99,81 @@ export async function getAllPosts(): Promise<NotionPost[]> {
   let hasMore = true;
 
   while (hasMore) {
-    const response = await getClient().search({
-      query: "",
-      page_size: 100,
-      start_cursor: cursor,
-    });
-
-    const posts = await Promise.all(
-      response.results.map(async (page) => {
-        try {
-          const pageData = await getClient().pages.retrieve({
-            page_id: page.id,
-          });
-
-          if (pageData.object === "page") {
-            const notionPage = pageData as NotionPage;
-            const properties = notionPage.properties;
-
-            const publishedProperty = properties.published as NotionCheckboxProperty | undefined;
-            const titleProperty = getPlainText(properties.title);
-
-            if (publishedProperty?.checkbox && titleProperty) {
-              const originalSlug = getPlainText(properties.slug);
-              const generatedSlug = slugify(titleProperty);
-              const baseSlug = originalSlug || generatedSlug || "post";
-
-              // pageId에서 하이픈 제거 (전체 32자리)
-              const pageIdWithoutHyphens = notionPage.id.replace(/-/g, "");
-
-              // slug + pageId 조합 (예: javascript-promise-8618d667c89b3708a1b2c3d4e5f6g7h8)
-              const validSlug = `${baseSlug}-${pageIdWithoutHyphens}`;
-
-              const publishedAtDate = getDate(properties.publishedAt);
-
-              // 날짜 유효성 재검증
-              const createdAt = notionPage.created_time || new Date().toISOString();
-              const updatedAt = notionPage.last_edited_time || new Date().toISOString();
-              const publishedAt = publishedAtDate || createdAt;
-
-              // 커버 이미지 URL 처리 (S3 URL인 경우 공개 프록시 URL로 변환)
-              const rawCoverImage = getImageUrl(properties.coverImage);
-              const coverImage = rawCoverImage ? convertToPublicNotionImageUrl(rawCoverImage, notionPage.id) : undefined;
-              const thumbnailImage = await resolveThumbnailImage(notionPage, coverImage);
-
-              return {
-                id: notionPage.id,
-                title: titleProperty,
-                slug: validSlug,
-                published: publishedProperty.checkbox,
-                createdAt,
-                publishedAt,
-                updatedAt,
-                tags: (getMultiSelect(properties.tags) || []).map((tag: string) => ({
-                  name: tag,
-                  slug: slugify(tag),
-                })),
-                excerpt: getPlainText(properties.excerpt),
-                coverImage,
-                thumbnailImage,
-              } as NotionPost;
-            }
-          }
-        } catch (pageError) {
-          const error = pageError as Error & { code?: string };
-          if (error.code !== "object_not_found") {
-            console.warn(`Failed to process page ${page.id}:`, error.message);
-          }
-        }
-        return null;
+    const response = await runNotionRequest(() =>
+      getClient().search({
+        query: "",
+        page_size: 100,
+        start_cursor: cursor,
       })
     );
+
+    const posts: Array<NotionPost | null> = [];
+    for (const page of response.results) {
+      try {
+        const pageData = await runNotionRequest(() =>
+          getClient().pages.retrieve({
+            page_id: page.id,
+          })
+        );
+
+        if (pageData.object === "page") {
+          const notionPage = pageData as NotionPage;
+          const properties = notionPage.properties;
+
+          const publishedProperty = properties.published as NotionCheckboxProperty | undefined;
+          const titleProperty = getPlainText(properties.title);
+
+          if (publishedProperty?.checkbox && titleProperty) {
+            const originalSlug = getPlainText(properties.slug);
+            const generatedSlug = slugify(titleProperty);
+            const baseSlug = originalSlug || generatedSlug || "post";
+
+            // pageId에서 하이픈 제거 (전체 32자리)
+            const pageIdWithoutHyphens = notionPage.id.replace(/-/g, "");
+
+            // slug + pageId 조합 (예: javascript-promise-8618d667c89b3708a1b2c3d4e5f6g7h8)
+            const validSlug = `${baseSlug}-${pageIdWithoutHyphens}`;
+
+            const publishedAtDate = getDate(properties.publishedAt);
+
+            // 날짜 유효성 재검증
+            const createdAt = notionPage.created_time || new Date().toISOString();
+            const updatedAt = notionPage.last_edited_time || new Date().toISOString();
+            const publishedAt = publishedAtDate || createdAt;
+
+            // 커버 이미지 URL 처리 (S3 URL인 경우 공개 프록시 URL로 변환)
+            const rawCoverImage = getImageUrl(properties.coverImage);
+            const coverImage = rawCoverImage ? convertToPublicNotionImageUrl(rawCoverImage, notionPage.id) : undefined;
+            const thumbnailImage = await resolveThumbnailImage(notionPage, coverImage);
+
+            posts.push({
+              id: notionPage.id,
+              title: titleProperty,
+              slug: validSlug,
+              published: publishedProperty.checkbox,
+              createdAt,
+              publishedAt,
+              updatedAt,
+              tags: (getMultiSelect(properties.tags) || []).map((tag: string) => ({
+                name: tag,
+                slug: slugify(tag),
+              })),
+              excerpt: getPlainText(properties.excerpt),
+              coverImage,
+              thumbnailImage,
+            } as NotionPost);
+            continue;
+          }
+        }
+      } catch (pageError) {
+        const error = pageError as Error & { code?: string };
+        if (error.code !== "object_not_found") {
+          console.warn(`Failed to process page ${page.id}:`, error.message);
+        }
+      }
+
+      posts.push(null);
+    }
 
     results.push(...posts.filter((post): post is NotionPost => post !== null));
     hasMore = response.has_more;
@@ -150,7 +207,7 @@ export async function getPostBySlug(slug: string, fetchContent = true): Promise<
 // pageId로 직접 포스트 조회
 export async function getPostByPageId(pageId: string, fetchContent = true): Promise<BlogPost> {
   // 페이지 메타데이터를 먼저 가져와서 last_edited_time으로 캐시 유효성 판단
-  const pageData = await getClient().pages.retrieve({ page_id: pageId });
+  const pageData = await runNotionRequest(() => getClient().pages.retrieve({ page_id: pageId }));
 
   if (!("properties" in pageData)) {
     throw new Error("Invalid page");
@@ -219,30 +276,31 @@ export async function getPostBlocks(pageId: string): Promise<NotionBlock[]> {
 
   // 모든 블록을 페이지네이션으로 가져오기
   while (hasMore) {
-    const response = await getClient().blocks.children.list({
-      block_id: pageId,
-      page_size: 100,
-      start_cursor: cursor,
-    });
-
-    const blocks = await Promise.all(
-      response.results.map(async (block) => {
-        const notionBlock = block as NotionBlockType;
-        const baseBlock = {
-          id: notionBlock.id,
-          type: notionBlock.type,
-          content: extractBlockContent(notionBlock),
-          children: undefined as NotionBlock[] | undefined,
-        };
-
-        // children이 있는 경우 재귀적으로 가져오기
-        if (notionBlock.has_children) {
-          baseBlock.children = await getPostBlocks(notionBlock.id);
-        }
-
-        return baseBlock;
+    const response = await runNotionRequest(() =>
+      getClient().blocks.children.list({
+        block_id: pageId,
+        page_size: 100,
+        start_cursor: cursor,
       })
     );
+
+    const blocks: NotionBlock[] = [];
+    for (const block of response.results) {
+      const notionBlock = block as NotionBlockType;
+      const baseBlock = {
+        id: notionBlock.id,
+        type: notionBlock.type,
+        content: extractBlockContent(notionBlock),
+        children: undefined as NotionBlock[] | undefined,
+      };
+
+      // children이 있는 경우 재귀적으로 가져오기
+      if (notionBlock.has_children) {
+        baseBlock.children = await getPostBlocks(notionBlock.id);
+      }
+
+      blocks.push(baseBlock);
+    }
 
     allBlocks.push(...blocks);
 
@@ -258,7 +316,12 @@ export async function getPostsByTag(tag: string): Promise<BlogPost[]> {
   const posts = await getAllPosts();
   const filteredPosts = posts.filter((post) => post.tags.some((t) => t.name === tag));
 
-  return Promise.all(filteredPosts.map((post) => getPostBySlug(post.slug)));
+  const fullPosts: BlogPost[] = [];
+  for (const post of filteredPosts) {
+    fullPosts.push(await getPostBySlug(post.slug));
+  }
+
+  return fullPosts;
 }
 
 // Helper functions

--- a/src/features/notion/service/notion-client.ts
+++ b/src/features/notion/service/notion-client.ts
@@ -23,6 +23,7 @@ import { readPageBlocksCache, writePageBlocksCache } from "./notion-cache";
 // Singleton client instance
 let client: Client | null = null;
 let lastNotionRequestAt = 0;
+let notionRequestQueue: Promise<void> = Promise.resolve();
 
 const NOTION_MIN_REQUEST_INTERVAL_MS = 400;
 const NOTION_MAX_RETRY_COUNT = 5;
@@ -32,14 +33,27 @@ function sleep(ms: number): Promise<void> {
 }
 
 async function waitForNotionRequestSlot(): Promise<void> {
-  const now = Date.now();
-  const elapsed = now - lastNotionRequestAt;
+  const previousRequest = notionRequestQueue;
+  let releaseRequestSlot!: () => void;
 
-  if (elapsed < NOTION_MIN_REQUEST_INTERVAL_MS) {
-    await sleep(NOTION_MIN_REQUEST_INTERVAL_MS - elapsed);
+  notionRequestQueue = new Promise<void>((resolve) => {
+    releaseRequestSlot = resolve;
+  });
+
+  await previousRequest;
+
+  try {
+    const now = Date.now();
+    const elapsed = now - lastNotionRequestAt;
+
+    if (elapsed < NOTION_MIN_REQUEST_INTERVAL_MS) {
+      await sleep(NOTION_MIN_REQUEST_INTERVAL_MS - elapsed);
+    }
+
+    lastNotionRequestAt = Date.now();
+  } finally {
+    releaseRequestSlot();
   }
-
-  lastNotionRequestAt = Date.now();
 }
 
 function isRateLimitError(error: unknown): boolean {
@@ -110,11 +124,14 @@ export async function getAllPosts(): Promise<NotionPost[]> {
     const posts: Array<NotionPost | null> = [];
     for (const page of response.results) {
       try {
-        const pageData = await runNotionRequest(() =>
-          getClient().pages.retrieve({
-            page_id: page.id,
-          })
-        );
+        const pageData =
+          page.object === "page" && "properties" in page
+            ? (page as NotionPage)
+            : ((await runNotionRequest(() =>
+                getClient().pages.retrieve({
+                  page_id: page.id,
+                })
+              )) as NotionPage);
 
         if (pageData.object === "page") {
           const notionPage = pageData as NotionPage;
@@ -284,23 +301,24 @@ export async function getPostBlocks(pageId: string): Promise<NotionBlock[]> {
       })
     );
 
-    const blocks: NotionBlock[] = [];
-    for (const block of response.results) {
-      const notionBlock = block as NotionBlockType;
-      const baseBlock = {
-        id: notionBlock.id,
-        type: notionBlock.type,
-        content: extractBlockContent(notionBlock),
-        children: undefined as NotionBlock[] | undefined,
-      };
+    const blocks = await Promise.all(
+      response.results.map(async (block) => {
+        const notionBlock = block as NotionBlockType;
+        const baseBlock = {
+          id: notionBlock.id,
+          type: notionBlock.type,
+          content: extractBlockContent(notionBlock),
+          children: undefined as NotionBlock[] | undefined,
+        };
 
-      // children이 있는 경우 재귀적으로 가져오기
-      if (notionBlock.has_children) {
-        baseBlock.children = await getPostBlocks(notionBlock.id);
-      }
+        // children이 있는 경우 재귀적으로 가져오기
+        if (notionBlock.has_children) {
+          baseBlock.children = await getPostBlocks(notionBlock.id);
+        }
 
-      blocks.push(baseBlock);
-    }
+        return baseBlock;
+      })
+    );
 
     allBlocks.push(...blocks);
 
@@ -316,12 +334,7 @@ export async function getPostsByTag(tag: string): Promise<BlogPost[]> {
   const posts = await getAllPosts();
   const filteredPosts = posts.filter((post) => post.tags.some((t) => t.name === tag));
 
-  const fullPosts: BlogPost[] = [];
-  for (const post of filteredPosts) {
-    fullPosts.push(await getPostBySlug(post.slug));
-  }
-
-  return fullPosts;
+  return Promise.all(filteredPosts.map((post) => getPostBySlug(post.slug)));
 }
 
 // Helper functions


### PR DESCRIPTION
## Changes

- Notion API 요청에 최소 간격과 429 retry를 추가
- 포스트 메타데이터/블록 조회의 병렬 Notion 호출을 순차 처리로 변경
- 이미지 빌드 스크립트에서 포스트별 이미지 URL 수집을 순차 처리로 변경

## Impact

- 빌드 중 Notion public API request rate limit 발생 가능성을 낮춤
- Notion 요청이 순차화되어 이미지 빌드 시간이 다소 늘어날 수 있음

## Testing

- pnpm lint
- pnpm typecheck