### PR TITLE
Align SEO URLs with canonical host

### DIFF
--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,4 +1,9 @@
 const POSTS_PER_PAGE = 20 as const;
-const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://changjun.dev";
+const normalizeBaseUrl = (url: string) => {
+  const baseUrl = url.replace(/\/+$/, "");
+  return baseUrl === "https://changjun.dev" ? "https://www.changjun.dev" : baseUrl;
+};
+
+const BASE_URL = normalizeBaseUrl(process.env.NEXT_PUBLIC_SITE_URL || "https://www.changjun.dev");
 
 export { BASE_URL, POSTS_PER_PAGE };


### PR DESCRIPTION
## What changed

- Normalize the shared `BASE_URL` default to `https://www.changjun.dev`.
- Coerce the legacy `https://changjun.dev` value to the www host before metadata, sitemap, robots, feeds, and JSON-LD consume it.

## Why

Production redirects non-www URLs to `www.changjun.dev`, but generated SEO signals were still pointing at the non-www host. That can make canonical, sitemap, robots, and structured data disagree with the URL Google actually reaches.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `NEXT_PUBLIC_SITE_URL=https://changjun.dev pnpm exec tsx -e "import { BASE_URL } from './src/shared/constants'; console.log(BASE_URL)"` -> `https://www.changjun.dev`
- `pnpm test:ci`

Note: full `pnpm build` was also run in the original checkout before creating this clean PR branch; it completed successfully, with existing Notion `object_not_found` warnings for page `2822acd7-2313-80a2-8590-000b40e264d1`.