### PR TITLE
조회수 재방문 집계 시간을 1시간으로 단축

### DIFF
--- a/src/app/api/posts/[slug]/views/route.ts
+++ b/src/app/api/posts/[slug]/views/route.ts
@@ -54,7 +54,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 /**
  * POST /api/posts/[slug]/views
  * 포스트 조회수를 증가시킵니다.
- * 새로고침 시마다 조회수가 증가합니다.
+ * 동일한 IP의 조회는 포스트별로 1시간에 한 번만 집계합니다.
  */
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
@@ -70,7 +70,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const viewedKey = getPostViewedKey(slug, identifier);
 
     const isNewView = await redis.set(viewedKey, "1", {
-      EX: 60 * 60 * 24,
+      EX: 60 * 60,
       NX: true,
     });
 


### PR DESCRIPTION
## 변경 내용

- 동일 IP·동일 게시글의 조회수 중복 방지 시간을 24시간에서 1시간으로 단축했습니다.
- 실제 집계 정책과 어긋나던 API 주석을 수정했습니다.

## 변경 이유

기존에는 방문자가 게시글을 다시 읽어도 24시간 동안 조회수가 반영되지 않았습니다. 기본적인 새로고침 중복 방지는 유지하면서, 1시간 후의 재방문은 새로운 조회로 집계합니다.

## 영향

- 같은 IP에서 같은 글을 1시간 안에 반복 조회하면 한 번만 집계됩니다.
- 1시간이 지나면 같은 방문자의 재방문도 다시 집계됩니다.

## 검증

- ESLint: 변경 라우트 통과
- TypeScript `--noEmit`: 통과
- Jest: 11 suites, 49 tests 통과
