### PR TITLE
fix: Keep Notion image render width stable

### DIFF
--- a/src/features/notion/ui/blocks/ImageBlock.tsx
+++ b/src/features/notion/ui/blocks/ImageBlock.tsx
@@ -30,7 +30,8 @@ export function ImageBlock({ url, caption, enableModal = false, onImageClick }: 
       width={optimizedImage.width || 0}
       height={optimizedImage.height || 0}
       sizes="(max-width: 640px) calc(100vw - 2rem), 960px"
-      className={`block h-auto rounded-lg mx-auto ${optimizedImage.width ? "w-auto max-w-full" : "w-full"}`}
+      className="block h-auto max-w-full mx-auto"
+      style={optimizedImage.width ? { width: optimizedImage.width } : undefined}
       unoptimized={isGif}
     />
   );
@@ -41,7 +42,7 @@ export function ImageBlock({ url, caption, enableModal = false, onImageClick }: 
         <button
           type="button"
           onClick={onImageClick}
-          className="block max-w-full rounded-lg mx-auto cursor-pointer hover:opacity-90 transition-opacity"
+          className="block max-w-full mx-auto cursor-pointer hover:opacity-90 transition-opacity"
           aria-label={caption ? `${caption} 크게 보기` : "이미지 크게 보기"}
         >
           {image}

--- a/src/features/notion/ui/blocks/ImageWithModal.tsx
+++ b/src/features/notion/ui/blocks/ImageWithModal.tsx
@@ -35,7 +35,7 @@ export function ImageWithModal({ url, caption }: ImageWithModalProps) {
             width={optimizedImage.width || 0}
             height={optimizedImage.height || 0}
             sizes="100vw"
-            className="max-w-full max-h-[90vh] w-auto h-auto rounded-lg object-contain"
+            className="max-w-full max-h-[90vh] w-auto h-auto object-contain"
             unoptimized={isGif}
           />
         </div>


### PR DESCRIPTION
## Changes
- Render Notion images at their mapped intrinsic width instead of the width of the selected responsive source.
- Keep images responsive with `max-width: 100%`.
- Remove rounded corners from article images and their enlarged modal view.

## Testing
- `pnpm test:ci`
- `pnpm lint`
- `pnpm typecheck`