### PR TITLE
fix: Restore fallback width for unmapped Notion images

### DIFF
--- a/src/features/notion/ui/blocks/ImageBlock.test.tsx
+++ b/src/features/notion/ui/blocks/ImageBlock.test.tsx
@@ -1,0 +1,48 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { getOptimizedImageData } from "../../../../shared/utils/imageMapper";
+import { ImageBlock } from "./ImageBlock";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: function MockImage({
+    unoptimized,
+    alt = "",
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & { unoptimized?: boolean }) {
+    void unoptimized;
+
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img alt={alt} {...props} />;
+  },
+}));
+
+jest.mock("../../../../shared/utils/imageMapper", () => ({
+  getOptimizedImageData: jest.fn(),
+}));
+
+const mockGetOptimizedImageData = jest.mocked(getOptimizedImageData);
+
+describe("ImageBlock", () => {
+  it("fills the content width when optimized dimensions are unavailable", () => {
+    mockGetOptimizedImageData.mockReturnValue({ src: "https://example.com/notion-image.png" });
+
+    render(<ImageBlock url="https://example.com/notion-image.png" caption="fallback image" />);
+
+    expect(screen.getByRole("img", { name: "fallback image" })).toHaveClass("w-full");
+  });
+
+  it("keeps the intrinsic width when optimized dimensions are available", () => {
+    mockGetOptimizedImageData.mockReturnValue({
+      src: "/images/post/1.webp",
+      width: 640,
+      height: 360,
+    });
+
+    render(<ImageBlock url="https://example.com/notion-image.png" caption="optimized image" />);
+
+    const image = screen.getByRole("img", { name: "optimized image" });
+    expect(image).not.toHaveClass("w-full");
+    expect(image).toHaveStyle({ width: "640px" });
+  });
+});

--- a/src/features/notion/ui/blocks/ImageBlock.tsx
+++ b/src/features/notion/ui/blocks/ImageBlock.tsx
@@ -30,7 +30,7 @@ export function ImageBlock({ url, caption, enableModal = false, onImageClick }: 
       width={optimizedImage.width || 0}
       height={optimizedImage.height || 0}
       sizes="(max-width: 640px) calc(100vw - 2rem), 960px"
-      className="block h-auto max-w-full mx-auto"
+      className={`block h-auto max-w-full mx-auto ${optimizedImage.width ? "" : "w-full"}`}
       style={optimizedImage.width ? { width: optimizedImage.width } : undefined}
       unoptimized={isGif}
     />


### PR DESCRIPTION
## What changed

- Restore `w-full` only when generated image dimensions are unavailable.
- Preserve the exact intrinsic width behavior for mapped/optimized images.
- Add component regression tests for both mapped and unmapped image paths.

## Root cause

Notion content can refresh through ISR after deployment while `imageMapping.generated.ts` remains fixed at build time. When a refreshed image URL was absent from that mapping, `ImageBlock` rendered it with `width="0"` and no CSS width override, making the image invisible.

## Impact

Images that are newer than or missing from the generated mapping remain visible at the article content width. Optimized images with known dimensions keep their current non-upscaled rendering behavior.

## Validation

- `pnpm exec jest --runInBand` — 15 suites, 54 tests passed
- `pnpm lint` — passed with no warnings
- `pnpm typecheck` — passed
- Targeted regression test verified the fallback test fails before the fix and passes afterward

## Build note

`pnpm build` reached the existing pre-build image fetch and stopped because `NOTION_API_KEY` is unavailable in the isolated worktree. Compilation was therefore not exercised locally; CI/Vercel with repository credentials should cover that environment-dependent step.
