### PR TITLE
fix: Restore post list position on browser back

### DIFF
--- a/src/entities/post/ui/PostCard.tsx
+++ b/src/entities/post/ui/PostCard.tsx
@@ -3,6 +3,7 @@ import type { PostMetadata } from "../model/usePostsQuery";
 
 interface PostCardProps {
   post: PostMetadata;
+  onNavigate?: () => void;
 }
 
 function formatDate(date: Date) {
@@ -12,7 +13,7 @@ function formatDate(date: Date) {
   return `${year}.${month}.${day}`;
 }
 
-export function PostCard({ post }: PostCardProps) {
+export function PostCard({ post, onNavigate }: PostCardProps) {
   return (
     <article className="border-b border-gray-200 py-7 dark:border-gray-800">
       <div className="max-w-3xl">
@@ -24,6 +25,7 @@ export function PostCard({ post }: PostCardProps) {
           <h2 className="mb-2 text-xl font-bold leading-tight text-gray-950 sm:text-2xl dark:text-gray-50">
             <Link
               href={`/posts/${post.slug}`}
+              onClick={onNavigate}
               className="hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
             >
               {post.title}

--- a/src/entities/post/ui/PostList.test.tsx
+++ b/src/entities/post/ui/PostList.test.tsx
@@ -1,0 +1,134 @@
+import "@testing-library/jest-dom";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { PostMetadata } from "../model/usePostsQuery";
+import { PostList } from "./PostList";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: function MockLink({
+    href,
+    onClick,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) {
+    return (
+      <a
+        href={href}
+        onClick={(event) => {
+          event.preventDefault();
+          onClick?.(event);
+        }}
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  },
+}));
+
+const posts: PostMetadata[] = Array.from({ length: 45 }, (_, index) => ({
+  id: `post-${index + 1}`,
+  title: `Post ${index + 1}`,
+  slug: `post-${index + 1}`,
+  excerpt: `Excerpt ${index + 1}`,
+  publishedAt: new Date("2026-07-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-07-01T00:00:00.000Z"),
+  tags: [],
+}));
+
+let triggerIntersection: (() => void) | undefined;
+
+class MockIntersectionObserver {
+  constructor(callback: IntersectionObserverCallback) {
+    triggerIntersection = () => callback([{ isIntersecting: true } as IntersectionObserverEntry], this as unknown as IntersectionObserver);
+  }
+
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+describe("PostList history restoration", () => {
+  beforeEach(() => {
+    triggerIntersection = undefined;
+    window.history.replaceState({}, "", "/");
+    Object.defineProperty(window, "IntersectionObserver", {
+      configurable: true,
+      value: MockIntersectionObserver,
+    });
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      },
+    });
+    Object.defineProperty(window, "cancelAnimationFrame", {
+      configurable: true,
+      value: jest.fn(),
+    });
+    Object.defineProperty(window, "scrollTo", {
+      configurable: true,
+      value: jest.fn(),
+    });
+  });
+
+  it("stores the loaded count and scroll position before opening a post", () => {
+    window.history.replaceState({ __NA: true }, "", "/");
+    render(<PostList posts={posts} postsPerPage={20} />);
+
+    act(() => triggerIntersection?.());
+    expect(screen.getAllByRole("article")).toHaveLength(40);
+
+    Object.defineProperty(window, "scrollY", { configurable: true, value: 1600 });
+    fireEvent.click(screen.getByRole("link", { name: "Post 40" }));
+
+    expect(window.history.state.postList).toEqual({
+      selectedTag: null,
+      scrollY: 1600,
+      visibleCount: 40,
+    });
+    expect(window.history.state.__NA).toBe(true);
+  });
+
+  it("rebuilds the list before restoring scroll on a matching history entry", async () => {
+    window.history.replaceState(
+      {
+        postList: {
+          selectedTag: null,
+          scrollY: 1600,
+          visibleCount: 40,
+        },
+      },
+      "",
+      "/",
+    );
+
+    render(<PostList posts={posts} postsPerPage={20} />);
+
+    await waitFor(() => expect(screen.getAllByRole("article")).toHaveLength(40));
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 1600);
+  });
+
+  it("ignores history state saved for a different tag", () => {
+    window.history.replaceState(
+      {
+        postList: {
+          selectedTag: "React",
+          scrollY: 1600,
+          visibleCount: 40,
+        },
+      },
+      "",
+      "/",
+    );
+
+    render(<PostList posts={posts} postsPerPage={20} />);
+
+    expect(screen.getAllByRole("article")).toHaveLength(20);
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/src/entities/post/ui/PostList.tsx
+++ b/src/entities/post/ui/PostList.tsx
@@ -9,6 +9,32 @@ interface PostListProps {
   postsPerPage: number;
 }
 
+interface PostListHistoryState {
+  selectedTag: string | null;
+  scrollY: number;
+  visibleCount: number;
+}
+
+const POST_LIST_HISTORY_KEY = "postList";
+
+function getPostListHistoryState(): PostListHistoryState | null {
+  const savedState = window.history.state?.[POST_LIST_HISTORY_KEY] as Partial<PostListHistoryState> | undefined;
+
+  if (
+    !savedState ||
+    !Number.isInteger(savedState.visibleCount) ||
+    (savedState.visibleCount ?? 0) < 0 ||
+    typeof savedState.scrollY !== "number" ||
+    !Number.isFinite(savedState.scrollY) ||
+    savedState.scrollY < 0 ||
+    (savedState.selectedTag !== null && typeof savedState.selectedTag !== "string")
+  ) {
+    return null;
+  }
+
+  return savedState as PostListHistoryState;
+}
+
 // 태그 버튼 스타일 헬퍼
 const getButtonClassName = (isActive: boolean) => {
   const baseClasses = "px-5 py-2.5 rounded-full text-sm font-semibold transition-colors cursor-pointer";
@@ -22,25 +48,69 @@ export function PostList({ posts, postsPerPage }: PostListProps) {
   const [visibleCount, setVisibleCount] = useState(postsPerPage);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const observerRef = useRef<HTMLDivElement>(null);
+  const pendingScrollRestoreRef = useRef<PostListHistoryState | null>(null);
+  const didSyncTagRef = useRef(false);
 
   // URL에서 태그 읽기 (브라우저 네비게이션 지원)
   useEffect(() => {
-    const syncStateWithUrl = () => {
+    const restoreStateFromHistory = () => {
       const params = new URLSearchParams(window.location.search);
       const tag = params.get("tag");
       setSelectedTag(tag);
+
+      const savedState = getPostListHistoryState();
+      if (!savedState || savedState.selectedTag !== tag) return;
+
+      const availableCount = tag
+        ? posts.filter((post) => post.tags.some((postTag) => postTag.name === tag)).length
+        : posts.length;
+      const restoredVisibleCount = Math.min(
+        Math.max(savedState.visibleCount, postsPerPage),
+        availableCount,
+      );
+
+      pendingScrollRestoreRef.current = {
+        ...savedState,
+        visibleCount: restoredVisibleCount,
+      };
+      setVisibleCount(restoredVisibleCount);
     };
 
-    window.addEventListener("popstate", syncStateWithUrl);
-    syncStateWithUrl();
+    const handlePopState = () => restoreStateFromHistory();
+
+    window.addEventListener("popstate", handlePopState);
+    restoreStateFromHistory();
 
     return () => {
-      window.removeEventListener("popstate", syncStateWithUrl);
+      window.removeEventListener("popstate", handlePopState);
     };
-  }, []);
+  }, [posts, postsPerPage]);
+
+  useEffect(() => {
+    const pendingState = pendingScrollRestoreRef.current;
+    if (
+      !pendingState ||
+      pendingState.selectedTag !== selectedTag ||
+      visibleCount < pendingState.visibleCount
+    ) {
+      return;
+    }
+
+    const animationFrame = window.requestAnimationFrame(() => {
+      window.scrollTo(0, pendingState.scrollY);
+      pendingScrollRestoreRef.current = null;
+    });
+
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [selectedTag, visibleCount]);
 
   // 태그 변경 시 URL 업데이트
   useEffect(() => {
+    if (!didSyncTagRef.current) {
+      didSyncTagRef.current = true;
+      return;
+    }
+
     const url = new URL(window.location.href);
 
     if (selectedTag) {
@@ -50,7 +120,7 @@ export function PostList({ posts, postsPerPage }: PostListProps) {
     }
 
     url.searchParams.delete("page");
-    window.history.replaceState({}, "", url);
+    window.history.replaceState(window.history.state, "", url);
   }, [selectedTag]);
 
   // 태그 카운트와 태그 목록을 한 번에 계산 (성능 최적화)
@@ -79,6 +149,25 @@ export function PostList({ posts, postsPerPage }: PostListProps) {
     setVisibleCount((prev) => prev + postsPerPage);
   }, [postsPerPage]);
 
+  const saveListPosition = useCallback(() => {
+    const currentHistoryState =
+      window.history.state && typeof window.history.state === "object"
+        ? window.history.state
+        : {};
+
+    window.history.replaceState(
+      {
+        ...currentHistoryState,
+        [POST_LIST_HISTORY_KEY]: {
+          selectedTag,
+          scrollY: window.scrollY,
+          visibleCount,
+        } satisfies PostListHistoryState,
+      },
+      "",
+    );
+  }, [selectedTag, visibleCount]);
+
   useEffect(() => {
     const el = observerRef.current;
     if (!el || !hasMore) return;
@@ -98,6 +187,7 @@ export function PostList({ posts, postsPerPage }: PostListProps) {
 
   // 태그 변경 핸들러
   const handleTagClick = (tag: string | null) => {
+    pendingScrollRestoreRef.current = null;
     setSelectedTag(tag);
     setVisibleCount(postsPerPage);
   };
@@ -124,7 +214,7 @@ export function PostList({ posts, postsPerPage }: PostListProps) {
 
       <div className="mb-10 border-t border-gray-200 dark:border-gray-800">
         {visiblePosts.map((post) => (
-          <PostCard key={post.id} post={post} />
+          <PostCard key={post.id} post={post} onNavigate={saveListPosition} />
         ))}
       </div>
 


### PR DESCRIPTION
## What changed

- Save the home list's loaded item count, active tag, and scroll offset on the current browser history entry before opening a post.
- Restore enough list items first, then restore the previous scroll offset on browser back.
- Preserve Next.js App Router's internal history state when updating the tag URL.
- Add regression coverage for persistence, restoration order, tag isolation, and Next.js history-state preservation.

## Root cause

The infinite-scroll list always initialized `visibleCount` from `postsPerPage`. Returning from a post remounted a shorter list, so the browser and Next.js could not restore a scroll offset beyond the newly reduced document height.

## User impact

Readers who open a post from lower in the home feed and press Back return to the same loaded section and scroll position. A fresh visit to the home page does not inherit another history entry's position.

## Why not BFCache

Post links use Next.js client-side routing, so relying on full-document BFCache restoration would require giving up SPA navigation and would still depend on browser cache eligibility. The state is instead scoped to the exact history entry that needs restoration.

## Validation

- `pnpm exec jest --runInBand` — 16 suites, 57 tests passed
- `pnpm lint` — passed with no warnings
- `pnpm typecheck` — passed
- Regression tests failed before the implementation and pass afterward

## Build note

`pnpm build` stopped in the existing pre-build image fetch because `NOTION_API_KEY` is unavailable in the isolated worktree. Compilation was therefore not exercised locally; Vercel CI with repository credentials should cover the environment-dependent build.
