### PR TITLE
fix: Support Notion link previews and fourth-level headings

### DIFF
--- a/src/features/notion/service/notion-client.test.ts
+++ b/src/features/notion/service/notion-client.test.ts
@@ -1,4 +1,12 @@
-import { tagSlug } from "./notion-client";
+import { Client } from "@notionhq/client";
+import { adaptNotionBlocksToContentBlocks } from "../utils/blockAdapter";
+import { getPostBlocks, tagSlug } from "./notion-client";
+
+jest.mock("@notionhq/client", () => ({
+  Client: jest.fn(),
+}));
+
+const mockClient = jest.mocked(Client);
 
 describe("tagSlug", () => {
   it.each([
@@ -7,5 +15,79 @@ describe("tagSlug", () => {
     [" React & 상태 관리 ", "react-상태-관리"],
   ])("preserves URL-safe Unicode characters in %s", (value, expected) => {
     expect(tagSlug(value)).toBe(expected);
+  });
+});
+
+describe("getPostBlocks", () => {
+  const originalApiKey = process.env.NOTION_API_KEY;
+  const listBlocks = jest.fn();
+
+  beforeAll(() => {
+    process.env.NOTION_API_KEY = "test-api-key";
+    mockClient.mockImplementation(
+      () =>
+        ({
+          blocks: {
+            children: {
+              list: listBlocks,
+            },
+          },
+        }) as unknown as Client,
+    );
+  });
+
+  afterAll(() => {
+    if (originalApiKey === undefined) {
+      delete process.env.NOTION_API_KEY;
+    } else {
+      process.env.NOTION_API_KEY = originalApiKey;
+    }
+  });
+
+  it("preserves heading four text and adapts link previews as bookmarks", async () => {
+    listBlocks.mockResolvedValueOnce({
+      results: [
+        {
+          object: "block",
+          id: "heading-4",
+          type: "heading_4",
+          created_time: "2026-07-17T00:00:00.000Z",
+          last_edited_time: "2026-07-17T00:00:00.000Z",
+          has_children: false,
+          heading_4: {
+            rich_text: [{ plain_text: "Fourth-level heading", href: null }],
+          },
+        },
+        {
+          object: "block",
+          id: "link-preview",
+          type: "link_preview",
+          created_time: "2026-07-17T00:00:00.000Z",
+          last_edited_time: "2026-07-17T00:00:00.000Z",
+          has_children: false,
+          link_preview: {
+            url: "https://github.com/cssinjs/jss/issues/665",
+          },
+        },
+      ],
+      has_more: false,
+      next_cursor: null,
+    });
+
+    const contentBlocks = adaptNotionBlocksToContentBlocks(await getPostBlocks("page-id"));
+
+    expect(contentBlocks).toEqual([
+      expect.objectContaining({
+        id: "heading-4",
+        type: "heading",
+        level: 4,
+        fallbackText: "Fourth-level heading",
+      }),
+      expect.objectContaining({
+        id: "link-preview",
+        type: "bookmark",
+        url: "https://github.com/cssinjs/jss/issues/665",
+      }),
+    ]);
   });
 });

--- a/src/features/notion/service/notion-client.ts
+++ b/src/features/notion/service/notion-client.ts
@@ -483,6 +483,15 @@ function extractBlockContent(block: NotionBlockType): BlockContent {
           annotations: rt.annotations,
         })),
       };
+    case "heading_4":
+      return {
+        type: "rich_text" as const,
+        rich_text: block.heading_4.rich_text.map((rt) => ({
+          plain_text: rt.plain_text,
+          href: rt.href,
+          annotations: rt.annotations,
+        })),
+      };
     case "paragraph":
       return {
         type: "rich_text" as const,
@@ -552,6 +561,12 @@ function extractBlockContent(block: NotionBlockType): BlockContent {
         type: "bookmark" as const,
         url: block.bookmark.url,
         caption: extractText(block.bookmark.caption || []),
+      };
+    }
+    case "link_preview": {
+      return {
+        type: "bookmark" as const,
+        url: block.link_preview.url,
       };
     }
     case "table": {

--- a/src/features/notion/types/index.ts
+++ b/src/features/notion/types/index.ts
@@ -144,6 +144,14 @@ export interface NotionHeading3Block extends NotionBlockBase {
   };
 }
 
+export interface NotionHeading4Block extends NotionBlockBase {
+  type: "heading_4";
+  heading_4: {
+    rich_text: NotionRichText[];
+    color?: string;
+  };
+}
+
 export interface NotionBulletedListItemBlock extends NotionBlockBase {
   type: "bulleted_list_item";
   bulleted_list_item: {
@@ -210,6 +218,13 @@ export interface NotionBookmarkBlock extends NotionBlockBase {
   };
 }
 
+export interface NotionLinkPreviewBlock extends NotionBlockBase {
+  type: "link_preview";
+  link_preview: {
+    url: string;
+  };
+}
+
 export interface NotionTableBlock extends NotionBlockBase {
   type: "table";
   table: {
@@ -231,6 +246,7 @@ export type NotionBlockType =
   | NotionHeading1Block
   | NotionHeading2Block
   | NotionHeading3Block
+  | NotionHeading4Block
   | NotionBulletedListItemBlock
   | NotionNumberedListItemBlock
   | NotionCodeBlock
@@ -239,6 +255,7 @@ export type NotionBlockType =
   | NotionVideoBlock
   | NotionDividerBlock
   | NotionBookmarkBlock
+  | NotionLinkPreviewBlock
   | NotionTableBlock
   | NotionTableRowBlock;
 

--- a/src/features/notion/utils/blockAdapter.ts
+++ b/src/features/notion/utils/blockAdapter.ts
@@ -120,7 +120,8 @@ export function adaptNotionBlockToContentBlock(block: NotionBlock): ContentBlock
       };
       break;
 
-    case "bookmark": {
+    case "bookmark":
+    case "link_preview": {
       const { url, caption } = extractImageData(content);
       contentBlock = {
         id,
@@ -203,4 +204,3 @@ export function adaptNotionBlockToContentBlock(block: NotionBlock): ContentBlock
 export function adaptNotionBlocksToContentBlocks(blocks: NotionBlock[]): ContentBlockWithChildren[] {
   return blocks.map(adaptNotionBlockToContentBlock);
 }
-


### PR DESCRIPTION
## What changed

- Add the current Notion `heading_4` response shape and preserve its rich text through ingestion.
- Add the Notion `link_preview` response shape and normalize it to the existing bookmark card model.
- Reuse the existing heading and bookmark renderers instead of adding another UI path.
- Add an API-to-content regression test covering both blocks.

## Root cause

The Notion ingestion union and `extractBlockContent` switch only knew headings one through three and did not know `link_preview`. Fourth-level headings therefore reached the renderer with empty text, while link previews fell back to `[Unknown block type: link_preview]`.

## User impact

- Text entered as `#### heading` in Notion renders as an `h4` with its content intact.
- Pasted Notion link previews render as clickable bookmark cards instead of unknown-block text.

Notion's API exposes the original link-preview URL, not the complete GitHub-style preview metadata shown inside Notion, so this PR intentionally renders the existing URL card rather than fetching third-party Open Graph data.

## Validation

- `pnpm exec jest --runInBand` — 16 suites, 58 tests passed
- `pnpm lint` — passed with no warnings
- `pnpm typecheck` — passed
- The new API-to-content regression failed for both block types before the implementation and passes afterward

## Build note

`pnpm build` stopped in the existing pre-build image fetch because `NOTION_API_KEY` is unavailable in the isolated worktree. Vercel CI with repository credentials should cover the environment-dependent build.
