### PR TITLE
fix: Prevent duplicate Utterances comment requests

### DIFF
--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -311,7 +311,7 @@ export default async function PostPage({ params }: PostPageProps) {
 
                 <div className="mt-12 border-t border-gray-200 pt-8 dark:border-gray-800">
                   <h2 className="mb-6 text-2xl font-bold text-gray-900 dark:text-white">댓글</h2>
-                  <Comment repo="ckdwns9121/blog-comment" issueTerm="pathname" label="Comment" />
+                  <Comment key={slug} repo="ckdwns9121/blog-comment" issueTerm="pathname" label="Comment" />
                 </div>
               </footer>
             </article>

--- a/src/entities/comment/api/utterances.test.ts
+++ b/src/entities/comment/api/utterances.test.ts
@@ -1,0 +1,14 @@
+import { isUtterancesLoaded, updateUtterancesTheme } from "./utterances";
+
+describe("Utterances iframe helpers", () => {
+  it("only detects and updates an iframe owned by the supplied comment container", () => {
+    const currentPostContainer = document.createElement("div");
+    const stalePostFrame = document.createElement("iframe");
+    stalePostFrame.className = "utterances-frame";
+
+    document.body.append(stalePostFrame, currentPostContainer);
+
+    expect(isUtterancesLoaded(currentPostContainer)).toBe(false);
+    expect(updateUtterancesTheme(currentPostContainer, "github-dark")).toBe(false);
+  });
+});

--- a/src/entities/comment/api/utterances.ts
+++ b/src/entities/comment/api/utterances.ts
@@ -25,8 +25,8 @@ export function loadUtterancesScript(
 /**
  * Utterances iframe에 테마 변경 메시지를 전송하는 함수
  */
-export function updateUtterancesTheme(theme: string): boolean {
-  const iframe = document.querySelector<HTMLIFrameElement>(".utterances-frame");
+export function updateUtterancesTheme(container: HTMLElement, theme: string): boolean {
+  const iframe = container.querySelector<HTMLIFrameElement>(".utterances-frame");
 
   if (iframe?.contentWindow) {
     iframe.contentWindow.postMessage({ type: "set-theme", theme }, "https://utteranc.es");
@@ -39,6 +39,6 @@ export function updateUtterancesTheme(theme: string): boolean {
 /**
  * Utterances iframe이 이미 로드되어 있는지 확인하는 함수
  */
-export function isUtterancesLoaded(): boolean {
-  return document.querySelector<HTMLIFrameElement>(".utterances-frame") !== null;
+export function isUtterancesLoaded(container: HTMLElement): boolean {
+  return container.querySelector<HTMLIFrameElement>(".utterances-frame") !== null;
 }

--- a/src/entities/comment/model/useUtterances.test.tsx
+++ b/src/entities/comment/model/useUtterances.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import { useUtterances } from "./useUtterances";
+import { isUtterancesLoaded, loadUtterancesScript, updateUtterancesTheme } from "../api";
+
+let currentTheme: string | undefined = "light";
+
+jest.mock("next-themes", () => ({
+  useTheme: () => ({ theme: currentTheme, resolvedTheme: currentTheme }),
+}));
+
+jest.mock("../api", () => ({
+  isUtterancesLoaded: jest.fn(),
+  loadUtterancesScript: jest.fn(),
+  updateUtterancesTheme: jest.fn(),
+}));
+
+function TestComment() {
+  const ref = useUtterances({ repo: "ckdwns9121/blog-comment" });
+  return <div ref={ref} />;
+}
+
+describe("useUtterances", () => {
+  beforeEach(() => {
+    currentTheme = "light";
+    jest.mocked(isUtterancesLoaded).mockReturnValue(false);
+    jest.mocked(loadUtterancesScript).mockClear();
+    jest.mocked(updateUtterancesTheme).mockClear();
+  });
+
+  it("does not append another Utterances script when only the theme changes", () => {
+    const { rerender } = render(<TestComment />);
+
+    currentTheme = "dark";
+    rerender(<TestComment />);
+
+    expect(loadUtterancesScript).toHaveBeenCalledTimes(1);
+    expect(updateUtterancesTheme).toHaveBeenCalledWith(expect.any(HTMLDivElement), "github-dark");
+  });
+});

--- a/src/entities/comment/model/useUtterances.ts
+++ b/src/entities/comment/model/useUtterances.ts
@@ -20,6 +20,7 @@ function getUtterancesTheme(theme: string | undefined): string {
  */
 export function useUtterances(config: UtterancesConfig) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const hasInitializedRef = useRef(false);
   const { theme, resolvedTheme } = useTheme();
 
   useEffect(() => {
@@ -28,19 +29,28 @@ export function useUtterances(config: UtterancesConfig) {
     const currentTheme = theme === "system" ? resolvedTheme : theme;
     const utterancesTheme = getUtterancesTheme(currentTheme);
 
-    // iframe이 이미 있으면 테마만 변경
-    if (isUtterancesLoaded()) {
-      updateUtterancesTheme(utterancesTheme);
+    // 테마 변경은 기존 위젯에만 전달한다. 스크립트가 iframe을 만들기 전에도
+    // 초기화 여부를 기억해 중복 요청을 만들지 않는다.
+    if (hasInitializedRef.current) {
+      updateUtterancesTheme(containerRef.current, utterancesTheme);
       return;
     }
 
-    // iframe이 없으면 초기 로드
+    // 서버 렌더링이나 이전 실행으로 이 컨테이너에 iframe이 있으면 재사용한다.
+    if (isUtterancesLoaded(containerRef.current)) {
+      hasInitializedRef.current = true;
+      updateUtterancesTheme(containerRef.current, utterancesTheme);
+      return;
+    }
+
+    // 컨테이너별로 한 번만 초기 로드
     loadUtterancesScript(containerRef.current, {
       repo: config.repo,
       issueTerm: config.issueTerm || "pathname",
       label: config.label || "Comment",
       theme: utterancesTheme,
     });
+    hasInitializedRef.current = true;
   }, [config.repo, config.issueTerm, config.label, theme, resolvedTheme]);
 
   return containerRef;


### PR DESCRIPTION
## Changes

- Scope Utterances iframe lookup to each post container.
- Prevent duplicate script loading during theme changes.
- Reinitialize the widget when navigating to another post.
- Add regression tests for iframe ownership and theme updates.

## Impact

- Reduces duplicate anonymous GitHub API requests while preserving existing Utterances comment Issues.

## Testing

- `pnpm test --runInBand`
- `pnpm typecheck`
- `pnpm lint`