### PR TITLE
style: Narrow blog reading layout

### DIFF
--- a/src/app/ClientLayout.tsx
+++ b/src/app/ClientLayout.tsx
@@ -28,7 +28,7 @@ export function ClientLayout({ children }: ClientLayoutProps) {
   return (
     <>
       <Header plugins={headerPlugins} mobilePlugins={mobileHeaderPlugins} />
-      <main id="main-content" className="flex-1 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 w-full" tabIndex={-1}>
+      <main id="main-content" className="flex-1 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 w-full" tabIndex={-1}>
         {children}
       </main>
     </>

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -267,8 +267,8 @@ export default async function PostPage({ params }: PostPageProps) {
         <ScrollProgress />
         <div className="py-10">
           <div className="mx-auto w-full">
-            <article className="mx-auto max-w-5xl">
-              <header className="mx-auto mb-6 max-w-5xl">
+            <article className="mx-auto max-w-3xl">
+              <header className="mx-auto mb-6 max-w-3xl">
                 <h1 className="mb-6 text-3xl leading-tight font-bold tracking-tight text-gray-950 md:text-4xl dark:text-gray-50">
                   {post.title}
                 </h1>
@@ -303,10 +303,10 @@ export default async function PostPage({ params }: PostPageProps) {
 
               <PostContent
                 blocks={post.content}
-                className="mx-auto max-w-5xl text-[1.0625rem] leading-[1.75] text-gray-800 dark:text-gray-200"
+                className="mx-auto max-w-3xl text-[1.0625rem] leading-[1.75] text-gray-800 dark:text-gray-200"
               />
 
-              <footer className="mx-auto mt-16 max-w-5xl pt-8">
+              <footer className="mx-auto mt-16 max-w-3xl pt-8">
                 <PostNavigation previousPost={previousPost} nextPost={nextPost} />
 
                 <div className="mt-12 border-t border-gray-200 pt-8 dark:border-gray-800">

--- a/src/entities/post/ui/PostList.tsx
+++ b/src/entities/post/ui/PostList.tsx
@@ -193,7 +193,7 @@ export function PostList({ posts, postsPerPage }: PostListProps) {
   };
 
   return (
-    <>
+    <div className="mx-auto max-w-3xl">
       {/* 태그 필터 */}
       <div className="pt-0 pb-5 sm:pb-7">
         <fieldset className="flex flex-wrap gap-2.5 sm:gap-3">
@@ -234,6 +234,6 @@ export function PostList({ posts, postsPerPage }: PostListProps) {
           <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-primary-600" />
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/src/shared/ui/Header/Header.tsx
+++ b/src/shared/ui/Header/Header.tsx
@@ -27,7 +27,7 @@ export function Header({ plugins, mobilePlugins = [], className }: HeaderProps) 
 
   return (
     <header className={cn("border-b border-gray-200 dark:border-dark-border", className)}>
-      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* 좌측 섹션 */}
           <div className="flex items-center gap-4">

--- a/src/shared/ui/Header/Header.tsx
+++ b/src/shared/ui/Header/Header.tsx
@@ -27,8 +27,9 @@ export function Header({ plugins, mobilePlugins = [], className }: HeaderProps) 
 
   return (
     <header className={cn("border-b border-gray-200 dark:border-dark-border", className)}>
-      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between h-16">
+      <div className="mx-auto w-full max-w-4xl px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <div className="flex items-center justify-between h-16">
           {/* 좌측 섹션 */}
           <div className="flex items-center gap-4">
             {/* 모바일 메뉴 버튼 */}
@@ -49,11 +50,11 @@ export function Header({ plugins, mobilePlugins = [], className }: HeaderProps) 
           <HeaderSection plugins={centerPlugins} position="center" className="hidden md:flex" />
           {/* 우측 섹션 */}
           <HeaderSection plugins={rightPlugins} position="right" />
-        </div>
+          </div>
 
-        {/* 모바일 메뉴 */}
-        {isMenuOpen && (
-          <div className="md:hidden border-t border-gray-200 dark:border-dark-border py-4">
+          {/* 모바일 메뉴 */}
+          {isMenuOpen && (
+            <div className="md:hidden border-t border-gray-200 dark:border-dark-border py-4">
             {/* 모바일 플러그인들 */}
             {mobilePlugins.map((plugin) => (
               <div key={plugin.id} className="mb-4 last:mb-0">
@@ -78,8 +79,9 @@ export function Header({ plugins, mobilePlugins = [], className }: HeaderProps) 
                 About
               </Link>
             </nav>
-          </div>
-        )}
+            </div>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/src/shared/ui/Header/Header.tsx
+++ b/src/shared/ui/Header/Header.tsx
@@ -27,7 +27,7 @@ export function Header({ plugins, mobilePlugins = [], className }: HeaderProps) 
 
   return (
     <header className={cn("border-b border-gray-200 dark:border-dark-border", className)}>
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* 좌측 섹션 */}
           <div className="flex items-center gap-4">


### PR DESCRIPTION
## Changes
- Reduce the shared header and page container from `max-w-5xl` to `max-w-4xl`.
- Constrain the post index to `max-w-3xl`.
- Constrain post headers, content, and footers to `max-w-3xl` for a shorter reading line.

## Impact
- Keeps mobile padding unchanged while making desktop reading and navigation more compact.

## Testing
- `pnpm test:ci`
- `pnpm lint`
- `pnpm typecheck`