### PR TITLE
fix: Map Notion code block languages to Prism aliases

### DIFF
--- a/src/features/notion/ui/blocks/CodeBlock.tsx
+++ b/src/features/notion/ui/blocks/CodeBlock.tsx
@@ -10,6 +10,18 @@ interface CodeBlockProps {
   language: string;
 }
 
+// Notion의 언어 문자열 중 refractor(Prism)에 별칭으로 등록되지 않은 것들을 매핑한다.
+// 매핑하지 않으면 refractor.highlight가 내부적으로 실패해 하이라이팅 없이 렌더링된다.
+const NOTION_LANGUAGE_TO_PRISM: Record<string, string> = {
+  "c++": "cpp",
+  "c#": "csharp",
+  "objective-c": "objectivec",
+};
+
+function normalizeLanguage(language: string): string {
+  return NOTION_LANGUAGE_TO_PRISM[language] ?? language;
+}
+
 /**
  * 코드 블록을 렌더링하는 컴포넌트
  */
@@ -20,7 +32,7 @@ export function CodeBlock({ code, language }: CodeBlockProps) {
   return (
     <div className="my-5 overflow-hidden rounded-lg">
       <SyntaxHighlighter
-        language={language}
+        language={normalizeLanguage(language)}
         style={isDark ? oneDark : oneLight}
         className="!m-0"
         showLineNumbers={false}


### PR DESCRIPTION
## Summary
- C++ code blocks were rendering without syntax highlighting. Notion returns the language as `"c++"`, but refractor/Prism only registers it under `"cpp"` with no matching alias, so `highlight()` throws internally and `react-syntax-highlighter` silently falls back to plain text.
- Added a small language map in `CodeBlock.tsx` to normalize Notion's language strings (`c++` → `cpp`, `c#` → `csharp`, `objective-c` → `objectivec`) before passing them to the highlighter. The other two share the exact same root cause and were verified against refractor's alias lists.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (61/61 passing, no regressions)
- [ ] Manually verify a C++ code block renders with highlighting on a real post