### PR TITLE
fix: 코드 블록 C++ 등 언어 하이라이팅 복구

### DIFF
--- a/src/features/notion/ui/blocks/CodeBlock.tsx
+++ b/src/features/notion/ui/blocks/CodeBlock.tsx
@@ -10,6 +10,22 @@ interface CodeBlockProps {
   language: string;
 }
 
+// Notion API의 언어 이름과 Prism이 인식하는 언어 키가 다른 경우 매핑
+const PRISM_LANGUAGE_MAP: Record<string, string> = {
+  "c++": "cpp",
+  "c#": "csharp",
+  "f#": "fsharp",
+  "objective-c": "objectivec",
+  "plain text": "text",
+  shell: "bash",
+  "vb.net": "vbnet",
+};
+
+function normalizeLanguage(language: string): string {
+  const lower = language.toLowerCase();
+  return PRISM_LANGUAGE_MAP[lower] ?? lower;
+}
+
 /**
  * 코드 블록을 렌더링하는 컴포넌트
  */
@@ -20,7 +36,7 @@ export function CodeBlock({ code, language }: CodeBlockProps) {
   return (
     <div className="my-5 overflow-hidden rounded-lg">
       <SyntaxHighlighter
-        language={language}
+        language={normalizeLanguage(language)}
         style={isDark ? oneDark : oneLight}
         className="!m-0"
         showLineNumbers={false}


### PR DESCRIPTION
## 문제

Notion API가 코드 블록 언어를 `c++`, `c#`, `plain text`, `shell` 등의 이름으로 내려주는데, react-syntax-highlighter(Prism)는 `cpp`, `csharp`, `text`, `bash` 키만 인식해서 해당 언어 코드 블록이 하이라이팅 없이 렌더링됐다.

## 수정

`CodeBlock`에서 Notion 언어 이름 → Prism 언어 키 매핑(`PRISM_LANGUAGE_MAP`)을 거치도록 정규화. 매핑에 없는 언어는 소문자화만 해서 그대로 전달.

## 검증

실제 라이브러리로 렌더 테스트:
- `language="c++"` → 토큰 0개 (기존 증상 재현)
- `language="cpp"` → 토큰 17개 (하이라이팅 정상)

변경 파일 tsc 에러 0건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)