### PR TITLE
feat: 본문 볼드에 브랜드 컬러 적용

### DIFF
--- a/src/features/notion/ui/RichTextRenderer.test.tsx
+++ b/src/features/notion/ui/RichTextRenderer.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { RichTextRenderer } from "./RichTextRenderer";
+import type { RichTextItem } from "../types";
+
+function item(overrides: Partial<RichTextItem>): RichTextItem {
+  return {
+    plain_text: "강조된 문장",
+    annotations: {
+      bold: false,
+      italic: false,
+      strikethrough: false,
+      underline: false,
+      code: false,
+      color: "default",
+    },
+    ...overrides,
+  } as RichTextItem;
+}
+
+describe("RichTextRenderer", () => {
+  it("renders bold text in the brand colour instead of inheriting body colour", () => {
+    render(<RichTextRenderer items={[item({ annotations: { bold: true } as RichTextItem["annotations"] })]} />);
+
+    const strong = screen.getByText("강조된 문장");
+    expect(strong.tagName).toBe("STRONG");
+    expect(strong).toHaveClass("text-primary-700", "dark:text-primary-300");
+  });
+
+  it("leaves plain text without a colour override", () => {
+    render(<RichTextRenderer items={[item({})]} />);
+
+    const span = screen.getByText("강조된 문장");
+    expect(span.tagName).toBe("SPAN");
+    expect(span.className).toBe("");
+  });
+
+  it("keeps bold styling when the text is also a link", () => {
+    render(
+      <RichTextRenderer
+        items={[
+          item({
+            href: "https://example.com",
+            annotations: { bold: true } as RichTextItem["annotations"],
+          }),
+        ]}
+      />,
+    );
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(screen.getByText("강조된 문장").tagName).toBe("STRONG");
+  });
+});

--- a/src/features/notion/ui/RichTextRenderer.tsx
+++ b/src/features/notion/ui/RichTextRenderer.tsx
@@ -30,7 +30,9 @@ function RichTextItem({ item }: RichTextItemProps) {
   // 텍스트 스타일 적용
   if (annotations) {
     if (annotations.bold) {
-      text = <strong>{text}</strong>;
+      // 볼드는 본문 색을 그대로 물려받아 검게 나오고 있었다.
+      // 브랜드 컬러를 입혀 강조가 눈에 띄게 한다.
+      text = <strong className="text-primary-700 dark:text-primary-300">{text}</strong>;
     }
     if (annotations.italic) {
       text = <em>{text}</em>;


### PR DESCRIPTION
본문의 볼드가 검은색으로만 나오던 문제를 고칩니다. 링크는 브랜드 컬러가 적용돼 있었는데 볼드만 빠져 있었습니다.

## 원인

`RichTextRenderer.tsx`에서 볼드를 `<strong>{text}</strong>`로만 감싸고 색 지정이 없어, 본문 색을 그대로 물려받고 있었습니다. 링크는 `text-primary-600`이 있어서 색이 바뀌었던 거고요.

## 색 선택

링크와 **같은 색을 쓰지 않고 한 단계 어긋나게** 잡았습니다.

| | 라이트 | 다크 |
|---|---|---|
| 링크 (기존) | `primary-600` | `primary-400` |
| **볼드 (추가)** | **`primary-700`** | **`primary-300`** |

이유 두 가지:

1. **링크와 혼동** — 볼드에 링크와 같은 색을 쓰면 클릭되는 줄 알고 눌러보게 됩니다. 한 단계 차이를 두면 브랜드 톤은 유지하면서 구분이 됩니다.
2. **대비** — 브랜드 원색 `primary-400`(#75A788)은 흰 배경 대비 약 2.5:1로 본문 텍스트에 쓰기엔 WCAG 기준에 못 미칩니다. `primary-700`(#395947)은 8.9:1로 AAA를 만족합니다.

`<strong>`의 기본 굵기는 건드리지 않았습니다. 색만 추가했습니다.

## 테스트

`RichTextRenderer`에 테스트가 없어서 3개 추가했습니다.

- 볼드에 브랜드 컬러가 붙는지
- 일반 텍스트에는 색 오버라이드가 없는지
- 링크 안의 볼드가 깨지지 않는지

typecheck ✅ / lint ✅ / test ✅ 21 suites, 73 tests

**렌더링은 눈으로 확인하지 못했습니다** — 로컬에 `.env`가 없어 Notion이 필요한 경로를 못 돌립니다. 색이 어둡거나 밝게 느껴지면 단계 조정은 한 줄입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
