### PR TITLE
fix: 이전/다음 글 내비게이션을 박스 두 줄로 변경

### DIFF
--- a/src/widgets/post-navigation/PostNavigation.test.tsx
+++ b/src/widgets/post-navigation/PostNavigation.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import PostNavigation from "./PostNavigation";
+import type { BlogPost } from "@/entities/post/model";
+
+function makePost(slug: string, title: string): BlogPost {
+  return {
+    id: slug,
+    title,
+    slug,
+    excerpt: "",
+    publishedAt: new Date(2026, 0, 1),
+    updatedAt: new Date(2026, 0, 1),
+    tags: [],
+    content: [],
+  } as unknown as BlogPost;
+}
+
+const previousPost = makePost(
+  "google-spread-sheets",
+  "Google Spread Sheets로 모두가 관리할 수 있는 다국어 시스템 만들기",
+);
+const nextPost = makePost("ast-codemod", "추상구문트리(AST)와 Codemod로 기존 코드를 안전하게 마이그레이션하기");
+
+describe("PostNavigation", () => {
+  it("renders nothing when there is neither a previous nor a next post", () => {
+    const { container } = render(<PostNavigation />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("stacks previous and next as separate list items", () => {
+    render(<PostNavigation previousPost={previousPost} nextPost={nextPost} />);
+
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    expect(screen.getByText("이전 글")).toBeInTheDocument();
+    expect(screen.getByText("다음 글")).toBeInTheDocument();
+  });
+
+  it("links each box to its post", () => {
+    render(<PostNavigation previousPost={previousPost} nextPost={nextPost} />);
+
+    const links = screen.getAllByRole("link");
+    expect(links[0]).toHaveAttribute("href", `/posts/${previousPost.slug}`);
+    expect(links[1]).toHaveAttribute("href", `/posts/${nextPost.slug}`);
+  });
+
+  it("draws a border around each box so the two do not run together", () => {
+    render(<PostNavigation previousPost={previousPost} nextPost={nextPost} />);
+
+    for (const link of screen.getAllByRole("link")) {
+      expect(link).toHaveClass("border", "border-line");
+    }
+  });
+
+  it("clamps long titles to two lines instead of letting them overflow", () => {
+    render(<PostNavigation previousPost={previousPost} />);
+
+    expect(screen.getByText(previousPost.title)).toHaveClass("line-clamp-2");
+  });
+
+  it("renders only the side that exists", () => {
+    render(<PostNavigation nextPost={nextPost} />);
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+    expect(screen.queryByText("이전 글")).toBeNull();
+    expect(screen.getByText("다음 글")).toBeInTheDocument();
+  });
+});

--- a/src/widgets/post-navigation/PostNavigation.tsx
+++ b/src/widgets/post-navigation/PostNavigation.tsx
@@ -9,86 +9,65 @@ interface PostNavigationProps {
   className?: string;
 }
 
+interface NavigationItemProps {
+  post: BlogPost;
+  direction: "previous" | "next";
+}
+
+/**
+ * 이전/다음 글 하나를 박스로 렌더링한다.
+ *
+ * 이전에는 두 글을 가로로 나란히 두고 truncate로 잘랐는데, 바깥 flex
+ * 아이템에 min-w-0이 없어 제목이 자기 칸을 넘어 서로 붙어 버렸다.
+ * 세로로 쌓고 line-clamp로 두 줄까지 접어 넘칠 수 없게 한다.
+ */
+function NavigationItem({ post, direction }: NavigationItemProps) {
+  const isPrevious = direction === "previous";
+  const Chevron = isPrevious ? ChevronLeftIcon : ChevronRightIcon;
+
+  return (
+    <Link
+      href={`/posts/${post.slug}`}
+      className={`group border-line hover:border-primary-600 dark:hover:border-primary-400 flex items-center gap-3 border p-4 transition-colors ${
+        isPrevious ? "" : "flex-row-reverse"
+      }`}
+    >
+      <Chevron
+        aria-hidden="true"
+        className={`text-fg-subtle group-hover:text-primary-600 dark:group-hover:text-primary-400 h-5 w-5 shrink-0 transition-all ${
+          isPrevious ? "group-hover:-translate-x-1" : "group-hover:translate-x-1"
+        }`}
+      />
+
+      <div className={`min-w-0 flex-1 ${isPrevious ? "" : "text-right"}`}>
+        <span className="text-fg-subtle block text-xs">{isPrevious ? "이전 글" : "다음 글"}</span>
+        <span className="text-fg group-hover:text-primary-600 dark:group-hover:text-primary-400 mt-1 block line-clamp-2 font-medium transition-colors">
+          {post.title}
+        </span>
+      </div>
+    </Link>
+  );
+}
+
 export default function PostNavigation({ previousPost, nextPost, className = "" }: PostNavigationProps) {
   if (!previousPost && !nextPost) {
     return null;
   }
 
   return (
-    <nav aria-label="글 이동" className={`py-8 border-t border-gray-200 dark:border-gray-700 ${className}`}>
-      {/* 데스크톱 레이아웃 */}
-      <div className="hidden md:flex justify-between items-center">
-        {/* 이전 포스트 */}
-        <div className="flex-1">
-          {previousPost ? (
-            <Link
-              href={`/posts/${previousPost.slug}`}
-              className="group flex items-center space-x-3 text-gray-600 hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-400 transition-colors"
-            >
-              <ChevronLeftIcon className="w-5 h-5 group-hover:-translate-x-1 transition-transform flex-shrink-0" />
-              <div className="min-w-0 flex-1">
-                <div className="text-sm text-gray-500 dark:text-gray-500">이전 글</div>
-                <div className="font-medium truncate">{previousPost.title}</div>
-              </div>
-            </Link>
-          ) : (
-            <div></div>
-          )}
-        </div>
-
-        {/* 다음 포스트 */}
-        <div className="flex-1 text-right">
-          {nextPost ? (
-            <Link
-              href={`/posts/${nextPost.slug}`}
-              className="group flex items-center justify-end space-x-3 text-gray-600 hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-400 transition-colors"
-            >
-              <div className="min-w-0 flex-1 text-right">
-                <div className="text-sm text-gray-500 dark:text-gray-500">다음 글</div>
-                <div className="font-medium truncate">{nextPost.title}</div>
-              </div>
-              <ChevronRightIcon className="w-5 h-5 group-hover:translate-x-1 transition-transform flex-shrink-0" />
-            </Link>
-          ) : (
-            <div></div>
-          )}
-        </div>
-      </div>
-
-      {/* 모바일 레이아웃 */}
-      <div className="md:hidden space-y-4">
-        {/* 이전 포스트 */}
+    <nav aria-label="글 이동" className={`border-line border-t py-8 ${className}`}>
+      <ul className="flex flex-col gap-3">
         {previousPost && (
-          <Link
-            href={`/posts/${previousPost.slug}`}
-            className="group block p-4 bg-gray-50 dark:bg-gray-800 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-          >
-            <div className="flex items-center space-x-3">
-              <ChevronLeftIcon className="w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
-              <div className="min-w-0 flex-1">
-                <div className="text-sm text-gray-500 dark:text-gray-400 mb-1">이전 글</div>
-                <div className="font-medium text-gray-900 dark:text-white line-clamp-2">{previousPost.title}</div>
-              </div>
-            </div>
-          </Link>
+          <li>
+            <NavigationItem post={previousPost} direction="previous" />
+          </li>
         )}
-
-        {/* 다음 포스트 */}
         {nextPost && (
-          <Link
-            href={`/posts/${nextPost.slug}`}
-            className="group block p-4 bg-gray-50 dark:bg-gray-800 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-          >
-            <div className="flex items-center space-x-3">
-              <div className="min-w-0 flex-1">
-                <div className="text-sm text-gray-500 dark:text-gray-400 mb-1">다음 글</div>
-                <div className="font-medium text-gray-900 dark:text-white line-clamp-2">{nextPost.title}</div>
-              </div>
-              <ChevronRightIcon className="w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
-            </div>
-          </Link>
+          <li>
+            <NavigationItem post={nextPost} direction="next" />
+          </li>
         )}
-      </div>
+      </ul>
     </nav>
   );
 }


### PR DESCRIPTION
제목이 길면 이전 글과 다음 글의 제목이 **공백 없이 이어져 보이던** 문제를 고칩니다.

**Before** — "…다국어 시스템 만들기추상구문트리(AST)와…" 처럼 두 제목이 붙어버림
**After** — 각각 border 박스로 세로 배치, 제목은 최대 두 줄

## 원인

`truncate`가 걸려 있었는데도 넘친 이유는, 바깥 flex 아이템에 `min-w-0`이 없었기 때문입니다.

```tsx
<div className="flex-1">          {/* ← min-w-0 없음. 콘텐츠만큼 늘어남 */}
  <Link className="flex ...">
    <div className="min-w-0 flex-1">   {/* 여기만 있었음 */}
      <div className="font-medium truncate">{title}</div>
```

flex 아이템의 `min-width`는 기본값이 `auto`라 콘텐츠보다 작아지지 않습니다. 바깥 div가 제목 길이만큼 늘어나 버리니 안쪽 `truncate`가 자를 여지가 없었습니다.

## 수정

`min-w-0`을 하나 더 붙이는 것으로도 잘리기는 하지만, 그러면 긴 제목이 한 줄로 잘려 무슨 글인지 알 수 없습니다. 요청대로 **세로 두 줄 + border 박스**로 바꿨습니다.

- 이전/다음을 각각 `border` 박스로 세로 배치
- 제목은 `line-clamp-2` — 어떤 길이든 두 줄까지만, 넘칠 수 없음
- hover 시 테두리와 텍스트가 브랜드 컬러로, 화살표가 방향대로 이동
- 모서리는 각지게 (썸네일·로고와 톤 통일)

## 같이 정리한 것

**데스크톱/모바일 레이아웃 이중화를 없앴습니다.** 기존에는 `hidden md:flex`와 `md:hidden`으로 거의 같은 마크업을 두 벌 유지하고 있었는데, 세로로 쌓는 구조는 두 화면 모두에서 동작하므로 한 벌로 합쳤습니다. 94줄 → 74줄.

`<ul>` / `<li>` 구조로 바꿔서 스크린리더가 "항목 2개 목록"으로 읽습니다. 색은 새로 들어온 semantic 토큰(`border-line`, `text-fg`)을 씁니다.

## 테스트

이 컴포넌트에 테스트가 없어서 6개 추가했습니다 — 빈 상태, 두 개 배치, 링크 경로, border 적용, line-clamp 적용, 한쪽만 있는 경우.

typecheck ✅ / lint ✅ / test ✅ 21 suites, 76 tests

**렌더링은 눈으로 확인하지 못했습니다** (로컬 `.env` 없음). 박스 여백이나 두 박스 사이 간격(`gap-3`)은 보시고 알려주시면 조정하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
