### PR TITLE
fix: 검색 모달 결과 너비와 중복 X 아이콘 수정

### DIFF
--- a/src/features/search/ui/SearchModal.test.tsx
+++ b/src/features/search/ui/SearchModal.test.tsx
@@ -91,4 +91,24 @@ describe('SearchModal', () => {
     expect(screen.queryByText('검색을 준비하는 중...')).not.toBeInTheDocument();
     expect(screen.queryByText('검색 데이터를 불러오는 중...')).not.toBeInTheDocument();
   });
+
+  it('renders every search result as a full-width row', () => {
+    renderModal({ status: 'success', posts: [post] });
+
+    const result = screen.getByRole('button', { name: /검색 포스트/ });
+    expect(result).toHaveClass('w-full');
+  });
+
+  it('does not render a second clear icon inside the search field', () => {
+    renderModal({ status: 'success', posts: [post] });
+    fireEvent.change(screen.getByRole('searchbox', { name: '포스트 검색' }), {
+      target: { value: '검색' },
+    });
+
+    expect(screen.queryByRole('button', { name: '검색어 지우기' })).not.toBeInTheDocument();
+    expect(screen.getByRole('searchbox', { name: '포스트 검색' })).toHaveAttribute(
+      'type',
+      'text',
+    );
+  });
 });

--- a/src/features/search/ui/SearchModal.tsx
+++ b/src/features/search/ui/SearchModal.tsx
@@ -88,7 +88,8 @@ export function SearchModal({
               />
             </svg>
             <input
-              type="search"
+              type="text"
+              role="searchbox"
               value={query}
               onChange={(event) => {
                 setQuery(event.target.value);
@@ -98,28 +99,13 @@ export function SearchModal({
               aria-label="포스트 검색"
               placeholder="검색어를 입력하세요..."
               className={cn(
-                'w-full pl-10 pr-12 py-3 bg-gray-50 dark:bg-gray-900',
+                'w-full pl-10 pr-10 py-3 bg-gray-50 dark:bg-gray-900',
                 'border border-gray-300 dark:border-gray-700 rounded-lg',
                 'focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent',
                 'text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400',
               )}
               autoFocus
             />
-            {query && (
-              <button
-                type="button"
-                onClick={() => {
-                  setQuery('');
-                  setSelectedIndex(-1);
-                }}
-                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-                aria-label="검색어 지우기"
-              >
-                <svg aria-hidden="true" className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            )}
           </div>
         </div>
 
@@ -237,7 +223,7 @@ function SearchResultItem({
     <button
       type="button"
       className={cn(
-        'px-4 py-3 cursor-pointer transition-colors',
+        'w-full px-4 py-3 cursor-pointer transition-colors',
         'border-b border-gray-100 dark:border-gray-800 last:border-b-0',
         isSelected
           ? 'bg-primary-50 dark:bg-primary-900/20 border-primary-200 dark:border-primary-800'


### PR DESCRIPTION
## 변경 사항
- 검색 결과 버튼에 `w-full`을 적용해 선택/호버 영역이 모달 전체 너비를 차지하도록 수정
- 검색 입력의 커스텀 및 브라우저 기본 지우기 X 경로를 제거해 모달 닫기 X만 표시
- 결과 행 너비와 중복 지우기 버튼 방지 회귀 테스트 추가

## 검증
- `pnpm lint -- src/features/search/ui/SearchModal.tsx src/features/search/ui/SearchModal.test.tsx` 통과
- 테스트: 기존 환경의 `jest-axe` 모듈 누락으로 실행 전 중단
- 타입 검사: 기존 생성 타입/API 및 Notion 테스트 타입 오류로 실패 (이번 변경과 무관)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the search experience by removing the duplicate clear button.
  * Search results now display as full-width rows for better usability.
  * Updated the search field styling and semantics for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->